### PR TITLE
Améliorer la lisibilité des CTE dans les corrections SQL

### DIFF
--- a/docs/r2.06/td2/td2-correction.sql
+++ b/docs/r2.06/td2/td2-correction.sql
@@ -300,7 +300,7 @@ GROUP BY P.idV, P.dateDep;
 -- Q19 - c:1, t:6
 -- Quels sont les pays pour lesquels il y a plus de réservations que pour l'Espagne ?
 -- @difficulty 3
--- @tags jointure, groupement, calcul-vertical, imbrication, sous-requête
+-- @tags jointure, groupement, calcul-vertical, imbrication, sous-requête, cte
 PROMPT "Q19";
 
 WITH
@@ -322,7 +322,7 @@ HAVING COUNT(*) > (
 -- Q20 - c:1, t:1 (PRIVILEGIE)
 -- Quelles sont les catégories effectives comportant le plus de clients ?
 -- @difficulty 3
--- @tags groupement, calcul-vertical, imbrication, sous-requête, extrémum, null
+-- @tags groupement, calcul-vertical, imbrication, sous-requête, extrémum, null, cte
 PROMPT "Q20";
 
 WITH
@@ -343,7 +343,7 @@ WHERE nbClients >= ALL(
 -- Q21 - c:1, t:2
 -- Quels sont les pays pour lesquels il y a le plus de réservations ?
 -- @difficulty 3
--- @tags jointure, groupement, calcul-vertical, imbrication, sous-requête, extrémum
+-- @tags jointure, groupement, calcul-vertical, imbrication, sous-requête, extrémum, cte
 PROMPT "Q21";
 
 WITH
@@ -419,7 +419,7 @@ WHERE
 -- Q25 - c:1, t:2
 -- Quelles sont les libellés des options gratuites pour au moins un voyage et payante pour au moins un autre ? Donner deux formulations différentes.
 -- @difficulty 3
--- @tags jointure, imbrication, semi-jointure, null
+-- @tags jointure, imbrication, semi-jointure, null, cte
 PROMPT "Q25 - V1";
 
 SELECT DISTINCT libelle
@@ -516,7 +516,7 @@ WHERE code IN (
 -- Q27 - c:3, t:7
 -- Quels sont les numéros, noms et prénoms des autres clients ayant réservé pour un des voyages réservé par Arnaud Peyroche ?
 -- @difficulty 3
--- @tags jointure, imbrication, semi-jointure, sous-requête
+-- @tags jointure, imbrication, semi-jointure, sous-requête, cte
 PROMPT "Q27";
 
 WITH
@@ -554,7 +554,7 @@ WHERE categorie = 'PRIVILEGIE';
 -- Q29 - c:3, t:1
 -- Quels sont les numéros, noms et prénoms des clients ayant fait une réservation avec un nombre total maximal de personnes ?
 -- @difficulty 3
--- @tags jointure, calcul-vertical, imbrication, sous-requête, extrémum, null
+-- @tags jointure, calcul-vertical, imbrication, sous-requête, extrémum, null, cte
 PROMPT "Q29";
 
 WITH
@@ -628,7 +628,7 @@ FROM Client
 -- Q34 - c:2, t:26
 -- Quels sont les numéros et noms des clients qui n'ont fait aucune réservation pour un voyage au Maroc ? Donnez deux formulations : une avec jointure externe et une avec test de non-existence.
 -- @difficulty 3
--- @tags jointure-externe, jointure, imbrication, not-exists, anti-jointure
+-- @tags jointure-externe, jointure, imbrication, not-exists, anti-jointure, cte
 -- Version avec jointure externe.
 PROMPT "Q34 - Version avec jointure externe";
 

--- a/docs/r2.06/td3/td3-correction.sql
+++ b/docs/r2.06/td3/td3-correction.sql
@@ -555,7 +555,7 @@ WHERE N.numEt IS NULL;
 -- Q21 - c:2, t:41
 -- Quels sont les noms et prénoms des étudiants n'ayant eu aucun enseignement de Marc Laporte ?
 -- @difficulty 3
--- @tags jointure, anti-jointure, imbrication, not-exists, jointure-externe
+-- @tags jointure, anti-jointure, imbrication, not-exists, jointure-externe, cte
 PROMPT "Q21 - V1";
 
 SELECT nomEt, prenomEt

--- a/docs/r2.06/td5/td5-correction.sql
+++ b/docs/r2.06/td5/td5-correction.sql
@@ -277,7 +277,7 @@ WHERE codePere IS NULL;
 -- Q10 - c:1, t:16
 -- Présenter, de manière hiérarchique, les libellés de tous les sous-modules du module Informatique 2de année.
 -- @difficulty 2
--- @tags récursion
+-- @tags récursion, cte
 PROMPT "Q10";
 
 SELECT LPAD('-', 2 * LEVEL, '-') || libelle
@@ -307,7 +307,7 @@ WHERE libelle <> 'INFORMATIQUE 2DE ANNEE';
 -- Q11 - c:1, t:7
 -- Présenter, de manière hiérarchique, les libellés du module Outils modèles génie logiciel et de tous ses sous-modules.
 -- @difficulty 2
--- @tags récursion
+-- @tags récursion, cte
 PROMPT "Q11";
 
 SELECT LPAD('-', 2 * LEVEL, '-') || libelle
@@ -335,7 +335,7 @@ FROM DescModule;
 -- Q12 - c:1, t:5
 -- Présenter, de manière hiérarchique, les libellés de tous les modules d'où est issu le module Bases de données.
 -- @difficulty 2
--- @tags récursion, tri
+-- @tags récursion, tri, cte
 PROMPT "Q12";
 
 SELECT LPAD('-', 2 * (MAX(LEVEL) OVER () + 1 - LEVEL), '-') || libelle
@@ -365,7 +365,7 @@ ORDER BY lvl DESC;
 -- Q13 - c:1, t:13
 -- Présenter, de manière hiérarchique, les libellés de tous les sous-modules de la discipline Informatique, subordonnés au module Informatique 2e année, à l'exception du module Bases de données.
 -- @difficulty 3
--- @tags récursion, sélection
+-- @tags récursion, sélection, cte
 PROMPT "Q13";
 
 SELECT LPAD('-', 2 * LEVEL, '-') || libelle
@@ -469,7 +469,7 @@ WHERE NOT EXISTS (
 -- Q16 - c:3, t:3
 -- Quels sont les numéros, noms et prénoms des étudiants ayant eu, pour le module Conception de SI, tous les Professeurs enseignant ce module ?
 -- @difficulty 3
--- @tags division, not-exists, jointure, groupement, calcul-vertical
+-- @tags division, not-exists, jointure, groupement, calcul-vertical, cte
 PROMPT "Q16 - Version double NOT EXISTS";
 
 SELECT numEt, nomEt, prenomEt
@@ -564,7 +564,7 @@ HAVING COUNT(DISTINCT Et.numEt) = (
 -- Q18 - c:1, t:13
 -- Présenter, de manière hiérarchique, les libellés de tous les sous-modules de la discipline Informatique subordonnés au module Informatique 2de année à l'exception du module Codage et circuits et de tous ses éventuels sous-modules.
 -- @difficulty 3
--- @tags récursion, sélection
+-- @tags récursion, sélection, cte
 PROMPT "Q18";
 
 SELECT LPAD('-', 2 * LEVEL, '-') || libelle
@@ -596,7 +596,7 @@ WHERE discipline = 'INFORMATIQUE';
 -- Q19 - c:1, t:24
 -- Présenter, de manière hiérarchique, les modules suivis par l'étudiant Jérôme Atlani ?
 -- @difficulty 3
--- @tags récursion, jointure, imbrication, semi-jointure
+-- @tags récursion, jointure, imbrication, semi-jointure, cte
 PROMPT "Q19";
 
 SELECT LPAD('-', 2 * (MAX(LEVEL) OVER () + 1 - LEVEL), '-') || libelle
@@ -670,7 +670,7 @@ HAVING MIN(moyTest) >= 10;
 -- Q21 - c:3, t:19
 -- Quels sont les numéros, noms et prénoms des étudiants ayant des moyennes dans un module subordonnés au module Principes des BD ?
 -- @difficulty 2
--- @tags jointure, imbrication, semi-jointure, récursion, distinct
+-- @tags jointure, imbrication, semi-jointure, récursion, distinct, cte
 PROMPT "Q21";
 
 SELECT DISTINCT Et.numEt, nomEt, prenomEt
@@ -705,7 +705,7 @@ WHERE code IN (SELECT code FROM DescModule);
 -- Q22 - c:3, t:29
 -- Donnez les numéros des étudiants, les écarts entre leurs éventuelles moyennes de test et la moins bonne moyenne de test du module ACSI ainsi que les écarts entre leurs éventuelles moyennes de test et la meilleure moyenne de test du module ACSI.
 -- @difficulty 3
--- @tags calcul-vertical, imbrication, sous-requête, sélection
+-- @tags calcul-vertical, imbrication, sous-requête, sélection, cte
 
 PROMPT "Q22 - V1";
 

--- a/scripts/generate-questions.py
+++ b/scripts/generate-questions.py
@@ -62,7 +62,7 @@ VALID_TAGS = {
     'union', 'intersection', 'différence', 'sous-requête',
     'exists', 'not-exists', 'tri', 'distinct', 'null',
     'vue', 'ddl', 'dml', 'transaction', 'récursion',
-    'calcul-vertical', 'calcul-horizontal', 'extrémum',
+    'calcul-vertical', 'calcul-horizontal', 'extrémum', 'cte',
 }
 
 


### PR DESCRIPTION
## Summary

Closes #1

- Ajout d'alternatives CTE (`WITH`) pour les sous-requêtes dans le `FROM`/`JOIN` (R2.06 TD2, TD3, TD5)
- Renommage de toutes les CTE génériques (`T`, `T1`, `E`, `N`…) en noms porteurs de sens (`ReservationMaroc`, `NbProfParModule`, `EtudiantDeMarcLaporte`…)
- Ajout du tag `cte` dans `VALID_TAGS` et application à 23 questions

## Test plan

- [x] `sqlfluff lint` : 0 erreur sur les 3 fichiers modifiés
- [x] Oracle 100% : td2 (48/48), td3 (53/53), td5 (44/44)