### PR TITLE
fix: Supprimer les annotations sqlfluff des PDF et de la page stats

### DIFF
--- a/scripts/generate-questions.py
+++ b/scripts/generate-questions.py
@@ -449,6 +449,21 @@ def _render_remark(remark, mode, out):
         out.append('')
 
 
+_NOQA_LINE_RE = re.compile(r'^--\s*noqa:\s*\S+.*$')
+_NOQA_SUFFIX_RE = re.compile(r'\s*--\s*noqa:\s*\S+')
+
+
+def _strip_noqa(sql):
+    """Retire les annotations sqlfluff noqa du SQL pour le rendu."""
+    lines = []
+    for line in sql.split('\n'):
+        if _NOQA_LINE_RE.match(line.strip()):
+            continue
+        line = _NOQA_SUFFIX_RE.sub('', line)
+        lines.append(line)
+    return '\n'.join(lines)
+
+
 def generate_markdown(parsed, mode='subject'):
     """Génère le Markdown des questions.
 
@@ -510,7 +525,7 @@ def generate_markdown(parsed, mode='subject'):
                         # Bloc SQL
                         if variant['sql']:
                             out.append('```sql')
-                            out.append(variant['sql'])
+                            out.append(_strip_noqa(variant['sql']))
                             out.append('```')
                             out.append('')
 

--- a/scripts/generate-stats.py
+++ b/scripts/generate-stats.py
@@ -27,6 +27,7 @@ _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
 parse_sql = _mod.parse_sql
 VALID_TAGS = _mod.VALID_TAGS
+_strip_noqa = _mod._strip_noqa
 
 
 # ---------------------------------------------------------------------------
@@ -95,7 +96,7 @@ def collect_questions(docs_dir):
                     if v.get("sql"):
                         variants.append({
                             "label": v.get("label"),
-                            "sql": v["sql"],
+                            "sql": _strip_noqa(v["sql"]),
                         })
                 questions.append({
                     "td_id": td_id,


### PR DESCRIPTION
## Summary

Closes #5

Les annotations `-- noqa: RF03`, `-- noqa: disable=all`, etc. étaient visibles dans les PDF de correction et la page statistiques. Ajout d'une fonction `_strip_noqa()` qui les retire au moment du rendu.

- `generate-questions.py` : nettoyage du SQL avant insertion dans le markdown (PDF)
- `generate-stats.py` : nettoyage des variantes SQL (page statistiques)

## Test plan

- [x] `generate-questions.py --mode correction` : 0 occurrence de `noqa` dans la sortie
- [x] `generate-stats.py` : 0 occurrence de `noqa` dans les pages HTML générées
- [x] Vérifier visuellement un PDF de correction (ex: R2.06 TD5 Q16)