### PR TITLE
chore: Remove orphaned R2.06 TD2 web manifest

### DIFF
--- a/docs/r2.06/td2/web-td.json
+++ b/docs/r2.06/td2/web-td.json
@@ -1,4 +1,0 @@
-{
-  "_comment": "Manifeste de la page web interactive du TD2 R2.06. oracleOnlyQuestions : questions dont aucune variante ne s'exécute sous SQLite (syntaxe Oracle/PostgreSQL only, ex. « > ALL (sous-requête) ») ; rendues non évaluables en ligne (énoncé seul + note). Vérifié via le dashboard test-sql.",
-  "oracleOnlyQuestions": ["20", "21"]
-}


### PR DESCRIPTION
## Contexte

Réconciliation d'une édition concurrente sur `main`. Le réécriveur `ALL/ANY` (`scripts/sql_quantifiers.py` + son jumeau `templates/web-td/js/sql-quantifiers.js`, parité prouvée) rend **TD2 Q20/Q21** (`>= ALL`) exécutables sous SQLite. La cible Make `web-r206-td2` ne passe donc **plus** `--manifest` : le fichier `docs/r2.06/td2/web-td.json` était devenu **orphelin** (plus référencé).

## Changement

Suppression du manifeste orphelin, seul résidu de la collision.

## Effet

- Aucun : le fichier n'était plus lu.
- TD2 reste **38/38** questions auto-évaluables.
- Les seules `oracleOnlyQuestions` restantes sont les questions **hiérarchiques** (`CONNECT BY`, TD5) — conforme à la demande initiale.

Aucune régression (vérifié en local sur R1.05 et R2.06).