### PR TITLE
feat: Contextual autocompletion in the query editor

### DIFF
--- a/.github/workflows/web-td.yml
+++ b/.github/workflows/web-td.yml
@@ -18,6 +18,7 @@ on:
       - 'scripts/verify-web-td.mjs'
       - 'scripts/sql_quantifiers.py'
       - 'scripts/test-sql-quantifiers.mjs'
+      - 'scripts/test-autocomplete.mjs'
       - 'scripts/td_correction.py'
       - 'scripts/sqlite_compat.py'
       - 'scripts/webtd_canon.py'
@@ -48,6 +49,7 @@ on:
       - 'scripts/verify-web-td.mjs'
       - 'scripts/sql_quantifiers.py'
       - 'scripts/test-sql-quantifiers.mjs'
+      - 'scripts/test-autocomplete.mjs'
       - 'scripts/td_correction.py'
       - 'scripts/sqlite_compat.py'
       - 'scripts/webtd_canon.py'
@@ -92,6 +94,10 @@ jobs:
       - name: Parité du réécriveur ALL/ANY (Python == JS)
         if: matrix.td == 'r206-td2'
         run: node scripts/test-sql-quantifiers.mjs
+
+      - name: Logique d'autocomplétion contextuelle
+        if: matrix.td == 'r206-td2'
+        run: node scripts/test-autocomplete.mjs
 
       - name: Génère et vérifie le site (hash Python == hash WASM)
         run: make verify-web-${{ matrix.td }}

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -138,5 +138,14 @@ check("FROM Client, Voyage -> colonnes des deux, pas de Reservation",
 r = suggest("sql", "SELECT ", SCHEMA, true);
 check("SELECT sans FROM -> repli toutes colonnes", labels(r).includes("NOM") && labels(r).includes("DATEDEP"));
 
+// ── Clause FROM : après FROM/virgule -> tables seules ; après une table -> jointures ──
+r = suggest("sql", "SELECT * FROM Voyage, ", SCHEMA, true);
+check("FROM Voyage, -> tables seules (aucun mot-clé)", r.items.length > 0 && r.items.every((i) => i.kind === "table"));
+r = suggest("sql", "SELECT * FROM ", SCHEMA, true);
+check("FROM (vide) -> tables seules", r.items.length > 0 && r.items.every((i) => i.kind === "table"));
+r = suggest("sql", "SELECT * FROM Voyage ", SCHEMA, true);
+check("FROM Voyage (après table) -> JOIN/WHERE, pas SELECT",
+  labels(r).includes("JOIN") && labels(r).includes("WHERE") && !labels(r).includes("SELECT"));
+
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -1,0 +1,66 @@
+// test-autocomplete.mjs - teste la logique de suggestion contextuelle (pure, sans DOM).
+//   node scripts/test-autocomplete.mjs
+import { suggest, buildAliasMap } from "../templates/web-td/js/autocomplete.js";
+
+const SCHEMA = {
+  tables: ["Client", "Voyage", "Reservation"],
+  columns: {
+    Client: ["numCl", "nom", "ville"],
+    Voyage: ["idV", "dateDep", "villeArr"],
+    Reservation: ["numCl", "idV", "dateRes"],
+  },
+  allColumns: ["numCl", "nom", "ville", "idV", "dateDep", "villeArr", "dateRes"],
+};
+
+let pass = 0, fail = 0;
+const labels = (r) => r.items.map((i) => i.label);
+function check(name, cond) {
+  if (cond) { pass++; } else { fail++; console.log(`  ✗ ${name}`); }
+}
+
+// ── SQL : contexte tables après FROM/JOIN ──
+let r = suggest("sql", "SELECT nom FROM Cl", SCHEMA);
+check("FROM Cl -> Client", labels(r).includes("Client") && r.word === "Cl" && r.items[0].kind === "table");
+
+r = suggest("sql", "SELECT * FROM Voyage JOIN Re", SCHEMA);
+check("JOIN Re -> Reservation", labels(r)[0] === "Reservation");
+
+// ── SQL : contexte colonnes ailleurs ──
+r = suggest("sql", "SELECT n", SCHEMA);
+check("SELECT n -> colonnes nom/numCl", labels(r).includes("nom") && labels(r).includes("numCl")
+  && r.items[0].kind === "col");
+
+// ── SQL : qualificateur alias. -> colonnes de la table ──
+r = suggest("sql", "SELECT * FROM Voyage v WHERE v.", SCHEMA);
+check("v. (alias Voyage) -> colonnes Voyage", JSON.stringify(labels(r)) === JSON.stringify(["idV", "dateDep", "villeArr"]));
+
+r = suggest("sql", "SELECT * FROM Voyage v, Reservation r WHERE r.i", SCHEMA);
+check("r.i (alias Reservation) -> idV", JSON.stringify(labels(r)) === JSON.stringify(["idV"]));
+
+r = suggest("sql", "SELECT ville FROM Client.", SCHEMA);
+check("Client. (table réelle) -> colonnes Client", JSON.stringify(labels(r)) === JSON.stringify(["numCl", "nom", "ville"]));
+
+// ── SQL : mot vide sans force -> rien ; avec force -> propositions ──
+check("SELECT (espace) sans force -> vide", suggest("sql", "SELECT ", SCHEMA).items.length === 0);
+check("SELECT (espace) avec force -> non vide", suggest("sql", "SELECT ", SCHEMA, true).items.length > 0);
+
+// ── buildAliasMap ──
+let m = buildAliasMap("SELECT * FROM Voyage V, Planning P WHERE V.idV = P.idV");
+check("aliasMap virgule", m.v === "Voyage" && m.p === "Planning");
+m = buildAliasMap("SELECT * FROM Voyage V INNER JOIN Reservation R ON V.idV = R.idV");
+check("aliasMap JOIN", m.v === "Voyage" && m.r === "Reservation");
+
+// ── Algèbre : opérateurs après := ──
+r = suggest("algebra", "R1 := SEL", SCHEMA);
+check("R1 := SEL -> SELECTION", labels(r)[0] === "SELECTION");
+
+// ── Algèbre : relations après ( ──
+r = suggest("algebra", "SELECTION (Vo", SCHEMA);
+check("( Vo -> Voyage", labels(r).includes("Voyage") && r.items[0].kind === "table");
+
+// ── Algèbre : attributs après / ──
+r = suggest("algebra", "SELECTION (Voyage / vi", SCHEMA);
+check("/ vi -> villeArr + ville", labels(r).includes("villeArr") && labels(r).includes("ville"));
+
+console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
+process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -122,5 +122,21 @@ check("JOINTURE(Voyage, Reservation/ -> attributs des deux", (() => {
 check("RENOMMAGE renomme le schéma suivi",
   eq(contextAttributes("R1 := RENOMMAGE(Voyage/villeArr -> destination)\nR2 := SELECTION(R1/", SCHEMA), ["idV", "dateDep", "destination"]));
 
+// ── SQL contextuel : colonnes non qualifiées restreintes aux tables du FROM/JOIN ──
+r = suggest("sql", "SELECT nom FROM Client WHERE ", SCHEMA, true);
+check("WHERE après FROM Client -> colonnes de Client, pas de Voyage",
+  labels(r).includes("NOM") && !labels(r).includes("DATEDEP"));
+// Le FROM peut être APRÈS le curseur (liste du SELECT) : scope via la requête complète.
+r = suggest("sql", "SELECT vi", SCHEMA, false, "SELECT vi FROM Voyage");
+check("SELECT vi ... FROM Voyage -> VILLEARR (Voyage) pas VILLE (Client)",
+  labels(r).includes("VILLEARR") && !labels(r).includes("VILLE"));
+// Plusieurs tables -> union de leurs colonnes.
+r = suggest("sql", "SELECT * FROM Client c, Voyage v WHERE ", SCHEMA, true);
+check("FROM Client, Voyage -> colonnes des deux, pas de Reservation",
+  labels(r).includes("NOM") && labels(r).includes("DATEDEP") && !labels(r).includes("DATERES"));
+// Sans FROM connu -> repli sur toutes les colonnes.
+r = suggest("sql", "SELECT ", SCHEMA, true);
+check("SELECT sans FROM -> repli toutes colonnes", labels(r).includes("NOM") && labels(r).includes("DATEDEP"));
+
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -1,6 +1,6 @@
 // test-autocomplete.mjs - teste la logique de suggestion contextuelle (pure, sans DOM).
 //   node scripts/test-autocomplete.mjs
-import { suggest, buildAliasMap } from "../templates/web-td/js/autocomplete.js";
+import { suggest, buildAliasMap, algebraAcceptSuffix } from "../templates/web-td/js/autocomplete.js";
 
 const SCHEMA = {
   tables: ["Client", "Voyage", "Reservation"],
@@ -65,6 +65,20 @@ check("( Vo -> VOYAGE", labels(r).includes("VOYAGE") && r.items[0].kind === "tab
 // ── Algèbre : attributs après / (en MAJUSCULES) ──
 r = suggest("algebra", "SELECTION (Voyage / vi", SCHEMA);
 check("/ vi -> VILLEARR + VILLE", labels(r).includes("VILLEARR") && labels(r).includes("VILLE"));
+
+// ── Algèbre : séparateur inséré après une relation/attribut accepté ──
+check("relation SELECTION -> /", algebraAcceptSuffix("SELECTION(", "table") === "/");
+check("relation PROJECTION -> /", algebraAcceptSuffix("PROJECTION (", "table") === "/");
+check("relation RENOMMAGE -> /", algebraAcceptSuffix("RENOMMAGE (", "table") === "/");
+check("attribut RENOMMAGE -> ' -> '", algebraAcceptSuffix("RENOMMAGE (R1 / NUMAV", "col") === " -> ");
+check("attribut SELECTION -> rien", algebraAcceptSuffix("SELECTION (AVION / ", "col") === "");
+check("1re relation UNION -> ', '", algebraAcceptSuffix("UNION(", "table") === ", ");
+check("2e relation JOINTURE -> ' / '", algebraAcceptSuffix("JOINTURE(A, ", "table") === " / ");
+check("2e relation JOINTURE_NATURELLE -> rien", algebraAcceptSuffix("JOINTURE_NATURELLE(A, ", "table") === "");
+
+// ── Algèbre : relation/attribut exact gardé sur appel explicite (Ctrl+Espace) ──
+check("exact relation gardé avec force", suggest("algebra", "SELECTION (VOYAGE", SCHEMA, true).items.some((i) => i.label === "VOYAGE"));
+check("exact relation ignoré sans force", !suggest("algebra", "SELECTION (VOYAGE", SCHEMA, false).items.some((i) => i.label === "VOYAGE"));
 
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -148,9 +148,10 @@ check("FROM Voyage (après table) -> JOIN/WHERE, pas SELECT",
   labels(r).includes("JOIN") && labels(r).includes("WHERE") && !labels(r).includes("SELECT"));
 
 // ── Position d'expression (SELECT, WHERE...) : colonnes + fonctions, pas de table ni clause ──
-r = suggest("sql", "SELECT DISTINCT ", SCHEMA, true);
-check("SELECT list -> pas de table ni mot-clé de clause, mais des fonctions",
-  !r.items.some((i) => i.kind === "table") && !labels(r).includes("FROM") && !labels(r).includes("WHERE") && labels(r).includes("COUNT"));
+r = suggest("sql", "SELECT ", SCHEMA, true);
+check("SELECT -> DISTINCT + fonctions, pas de table ni démarreur de clause",
+  labels(r).includes("DISTINCT") && labels(r).includes("COUNT")
+  && !r.items.some((i) => i.kind === "table") && !labels(r).includes("FROM") && !labels(r).includes("WHERE"));
 r = suggest("sql", "SELECT ", SCHEMA, true, "SELECT  FROM Voyage");
 check("SELECT list scopé Voyage -> colonnes de Voyage, pas de Client ni de table",
   labels(r).includes("VILLEARR") && !labels(r).includes("NOM") && !r.items.some((i) => i.kind === "table"));

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -180,5 +180,21 @@ check("GROUP BY -> colonnes, pas de DISTINCT", labels(r).includes("VILLEARR") &&
 r = suggest("sql", "SELECT * FROM Voyage ORDER BY ", SCHEMA, true);
 check("ORDER BY -> colonnes + ASC/DESC", labels(r).includes("VILLEARR") && labels(r).includes("ASC") && labels(r).includes("DESC"));
 
+// ── Limite 1 : le ')' d'un IN(...) / sous-requête -> AND/OR (pas comparateur) ──
+r = suggest("sql", "SELECT * FROM Voyage WHERE idV IN (SELECT numCl FROM Client) ", SCHEMA, true);
+check("après IN(sous-requête) -> AND/OR, pas de comparateur",
+  labels(r).includes("AND") && labels(r).includes("OR") && !labels(r).includes("="));
+// mais le ')' d'un agrégat reste un opérande -> comparateur
+r = suggest("sql", "SELECT idV FROM Voyage GROUP BY idV HAVING SUM(idV) ", SCHEMA, true);
+check("après agrégat SUM(...) -> comparateur", labels(r).includes("=") && !labels(r).includes("AND"));
+
+// ── Limite 2 : la portée d'une sous-requête sœur ne fuit pas dans la requête englobante ──
+r = suggest("sql", "SELECT * FROM Voyage WHERE idV IN (SELECT numCl FROM Client) AND ", SCHEMA, true);
+check("après une sous-requête sœur -> colonnes de Voyage seulement (pas Client)",
+  labels(r).includes("VILLEARR") && !labels(r).includes("NOM"));
+// dans une sous-requête, sa table est en portée (+ englobante pour corrélation)
+r = suggest("sql", "SELECT * FROM Voyage WHERE idV IN (SELECT numCl FROM Client WHERE n", SCHEMA, true);
+check("dans la sous-requête -> colonnes de Client visibles", labels(r).includes("NOM"));
+
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -147,5 +147,13 @@ r = suggest("sql", "SELECT * FROM Voyage ", SCHEMA, true);
 check("FROM Voyage (après table) -> JOIN/WHERE, pas SELECT",
   labels(r).includes("JOIN") && labels(r).includes("WHERE") && !labels(r).includes("SELECT"));
 
+// ── Position d'expression (SELECT, WHERE...) : colonnes + fonctions, pas de table ni clause ──
+r = suggest("sql", "SELECT DISTINCT ", SCHEMA, true);
+check("SELECT list -> pas de table ni mot-clé de clause, mais des fonctions",
+  !r.items.some((i) => i.kind === "table") && !labels(r).includes("FROM") && !labels(r).includes("WHERE") && labels(r).includes("COUNT"));
+r = suggest("sql", "SELECT ", SCHEMA, true, "SELECT  FROM Voyage");
+check("SELECT list scopé Voyage -> colonnes de Voyage, pas de Client ni de table",
+  labels(r).includes("VILLEARR") && !labels(r).includes("NOM") && !r.items.some((i) => i.kind === "table"));
+
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -164,6 +164,21 @@ check("WHERE colonne -> comparateurs + IN/LIKE/IS, pas de colonne ni DISTINCT",
 r = suggest("sql", "SELECT * FROM Voyage WHERE ", SCHEMA, true);
 check("WHERE (début) -> colonnes, pas de comparateur",
   labels(r).includes("VILLEARR") && !labels(r).includes("="));
+// ON et HAVING : même logique que WHERE.
+r = suggest("sql", "SELECT * FROM Voyage v JOIN Reservation r ON r.idV ", SCHEMA, true);
+check("ON colonne -> comparateurs", labels(r).includes("=") && labels(r).includes("IN"));
+// HAVING après un agrégat COUNT(*) -> comparateurs (jeton précédent ')').
+r = suggest("sql", "SELECT idV FROM Voyage GROUP BY idV HAVING COUNT(*) ", SCHEMA, true);
+check("HAVING COUNT(*) -> comparateurs", labels(r).includes("=") && labels(r).includes(">"));
+// Après une valeur -> connecteurs AND/OR (pas de colonnes ni comparateurs).
+r = suggest("sql", "SELECT * FROM Voyage WHERE villeArr = 'NICE' ", SCHEMA, true);
+check("après valeur -> AND/OR seulement", labels(r).includes("AND") && labels(r).includes("OR")
+  && !labels(r).includes("=") && !labels(r).includes("IDV"));
+// GROUP BY / ORDER BY : colonnes + fonctions (+ ASC/DESC), pas DISTINCT/AS.
+r = suggest("sql", "SELECT * FROM Voyage GROUP BY ", SCHEMA, true);
+check("GROUP BY -> colonnes, pas de DISTINCT", labels(r).includes("VILLEARR") && !labels(r).includes("DISTINCT"));
+r = suggest("sql", "SELECT * FROM Voyage ORDER BY ", SCHEMA, true);
+check("ORDER BY -> colonnes + ASC/DESC", labels(r).includes("VILLEARR") && labels(r).includes("ASC") && labels(r).includes("DESC"));
 
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -92,14 +92,13 @@ check("attribut complet sans séparateur (SELECTION) -> rien", a.type === "none"
 a = completionAction("sql", "WHERE ville = 'MAR", SCHEMA, true);
 check("dans une chaîne -> rien (action none)", a.type === "none");
 
-// ── Connecteurs ET/OU/NON : uniquement dans une condition (SELECTION, ET en JOINTURE) ──
-check("RENOMMAGE / -> pas de connecteur", !suggest("algebra", "RENOMMAGE (R1 / ", SCHEMA, true).items.some((i) => i.kind === "kw"));
-check("PROJECTION / -> pas de connecteur", !suggest("algebra", "PROJECTION (R1 / ", SCHEMA, true).items.some((i) => i.kind === "kw"));
-check("SELECTION / -> propose ET", suggest("algebra", "SELECTION (VOYAGE / ", SCHEMA, true).items.some((i) => i.label === "ET"));
-check("JOINTURE / -> propose ET mais pas OU", (() => {
-  const it = suggest("algebra", "JOINTURE (A, B / ", SCHEMA, true).items;
-  return it.some((i) => i.label === "ET") && !it.some((i) => i.label === "OU");
-})());
+// ── Après « / » : uniquement des attributs, jamais de connecteur (quel que soit l'opérateur) ──
+for (const ctx of ["SELECTION (VOYAGE / ", "RENOMMAGE (R1 / ", "PROJECTION (R1 / ", "JOINTURE (A, B / "]) {
+  check(`${ctx.trim()} -> attributs seuls`, !suggest("algebra", ctx, SCHEMA, true).items.some((i) => i.kind === "kw"));
+}
+// ── ET/OU/NON ne sont jamais proposés (ni en début d'expression) ──
+check("début d'expression -> opérateurs relationnels sans ET/OU/NON",
+  !suggest("algebra", "R1 := ", SCHEMA, true).items.some((i) => ["ET", "OU", "NON"].includes(i.label)));
 
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -18,27 +18,31 @@ function check(name, cond) {
   if (cond) { pass++; } else { fail++; console.log(`  ✗ ${name}`); }
 }
 
-// ── SQL : contexte tables après FROM/JOIN ──
+// ── SQL : contexte tables après FROM/JOIN (relations en MAJUSCULES) ──
 let r = suggest("sql", "SELECT nom FROM Cl", SCHEMA);
-check("FROM Cl -> Client", labels(r).includes("Client") && r.word === "Cl" && r.items[0].kind === "table");
+check("FROM Cl -> CLIENT", labels(r).includes("CLIENT") && r.word === "Cl" && r.items[0].kind === "table");
 
 r = suggest("sql", "SELECT * FROM Voyage JOIN Re", SCHEMA);
-check("JOIN Re -> Reservation", labels(r)[0] === "Reservation");
+check("JOIN Re -> RESERVATION", labels(r)[0] === "RESERVATION");
 
-// ── SQL : contexte colonnes ailleurs ──
+// ── SQL : contexte colonnes ailleurs (attributs en MAJUSCULES) ──
 r = suggest("sql", "SELECT n", SCHEMA);
-check("SELECT n -> colonnes nom/numCl", labels(r).includes("nom") && labels(r).includes("numCl")
+check("SELECT n -> colonnes NOM/NUMCL", labels(r).includes("NOM") && labels(r).includes("NUMCL")
   && r.items[0].kind === "col");
 
 // ── SQL : qualificateur alias. -> colonnes de la table ──
 r = suggest("sql", "SELECT * FROM Voyage v WHERE v.", SCHEMA);
-check("v. (alias Voyage) -> colonnes Voyage", JSON.stringify(labels(r)) === JSON.stringify(["idV", "dateDep", "villeArr"]));
+check("v. (alias Voyage) -> colonnes Voyage", JSON.stringify(labels(r)) === JSON.stringify(["IDV", "DATEDEP", "VILLEARR"]));
 
 r = suggest("sql", "SELECT * FROM Voyage v, Reservation r WHERE r.i", SCHEMA);
-check("r.i (alias Reservation) -> idV", JSON.stringify(labels(r)) === JSON.stringify(["idV"]));
+check("r.i (alias Reservation) -> IDV", JSON.stringify(labels(r)) === JSON.stringify(["IDV"]));
 
 r = suggest("sql", "SELECT ville FROM Client.", SCHEMA);
-check("Client. (table réelle) -> colonnes Client", JSON.stringify(labels(r)) === JSON.stringify(["numCl", "nom", "ville"]));
+check("Client. (table réelle) -> colonnes Client", JSON.stringify(labels(r)) === JSON.stringify(["NUMCL", "NOM", "VILLE"]));
+
+// ── Pas de complétion dans une chaîne non fermée ──
+check("dans une chaîne -> aucune complétion", suggest("sql", "WHERE ville = 'MAR", SCHEMA, true).items.length === 0);
+check("chaîne fermée -> complétion normale", suggest("sql", "WHERE ville = 'MAR' AND n", SCHEMA).items.length > 0);
 
 // ── SQL : mot vide sans force -> rien ; avec force -> propositions ──
 check("SELECT (espace) sans force -> vide", suggest("sql", "SELECT ", SCHEMA).items.length === 0);
@@ -54,13 +58,13 @@ check("aliasMap JOIN", m.v === "Voyage" && m.r === "Reservation");
 r = suggest("algebra", "R1 := SEL", SCHEMA);
 check("R1 := SEL -> SELECTION", labels(r)[0] === "SELECTION");
 
-// ── Algèbre : relations après ( ──
+// ── Algèbre : relations après ( (en MAJUSCULES) ──
 r = suggest("algebra", "SELECTION (Vo", SCHEMA);
-check("( Vo -> Voyage", labels(r).includes("Voyage") && r.items[0].kind === "table");
+check("( Vo -> VOYAGE", labels(r).includes("VOYAGE") && r.items[0].kind === "table");
 
-// ── Algèbre : attributs après / ──
+// ── Algèbre : attributs après / (en MAJUSCULES) ──
 r = suggest("algebra", "SELECTION (Voyage / vi", SCHEMA);
-check("/ vi -> villeArr + ville", labels(r).includes("villeArr") && labels(r).includes("ville"));
+check("/ vi -> VILLEARR + VILLE", labels(r).includes("VILLEARR") && labels(r).includes("VILLE"));
 
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -1,6 +1,6 @@
 // test-autocomplete.mjs - teste la logique de suggestion contextuelle (pure, sans DOM).
 //   node scripts/test-autocomplete.mjs
-import { suggest, buildAliasMap, algebraAcceptSuffix, completionAction } from "../templates/web-td/js/autocomplete.js";
+import { suggest, buildAliasMap, algebraAcceptSuffix, completionAction, contextAttributes } from "../templates/web-td/js/autocomplete.js";
 
 const SCHEMA = {
   tables: ["Client", "Voyage", "Reservation"],
@@ -63,8 +63,9 @@ r = suggest("algebra", "SELECTION (Vo", SCHEMA);
 check("( Vo -> VOYAGE", labels(r).includes("VOYAGE") && r.items[0].kind === "table");
 
 // ── Algèbre : attributs après / (en MAJUSCULES) ──
+// Contextuel : SELECTION(Voyage/ ne propose QUE les attributs de Voyage (pas ceux de Client).
 r = suggest("algebra", "SELECTION (Voyage / vi", SCHEMA);
-check("/ vi -> VILLEARR + VILLE", labels(r).includes("VILLEARR") && labels(r).includes("VILLE"));
+check("/ vi -> VILLEARR (de Voyage), pas VILLE (de Client)", labels(r).includes("VILLEARR") && !labels(r).includes("VILLE"));
 
 // ── Algèbre : séparateur inséré après une relation/attribut accepté ──
 check("relation SELECTION -> /", algebraAcceptSuffix("SELECTION(", "table") === "/");
@@ -99,6 +100,27 @@ for (const ctx of ["SELECTION (VOYAGE / ", "RENOMMAGE (R1 / ", "PROJECTION (R1 /
 // ── ET/OU/NON ne sont jamais proposés (ni en début d'expression) ──
 check("début d'expression -> opérateurs relationnels sans ET/OU/NON",
   !suggest("algebra", "R1 := ", SCHEMA, true).items.some((i) => ["ET", "OU", "NON"].includes(i.label)));
+
+// ── contextAttributes : attributs de l'opérande courant (table de base ET relation intermédiaire) ──
+const eq = (a, b) => JSON.stringify(a) === JSON.stringify(b);
+check("SELECTION(Voyage/ -> attributs de Voyage",
+  eq(contextAttributes("R1 := SELECTION(Voyage/", SCHEMA), ["idV", "dateDep", "villeArr"]));
+check("SELECTION(Client/ -> attributs de Client",
+  eq(contextAttributes("R1 := SELECTION(Client/", SCHEMA), ["numCl", "nom", "ville"]));
+// Relation intermédiaire : PROJECTION restreint le schéma.
+check("PROJECTION puis SELECTION(R1/ -> attributs projetés",
+  eq(contextAttributes("R1 := PROJECTION(Voyage/idV, dateDep)\nR2 := SELECTION(R1/", SCHEMA), ["idV", "dateDep"]));
+// SELECTION préserve le schéma ; RENOMMAGE(R1/ voit donc les attributs de Voyage.
+check("SELECTION puis RENOMMAGE(R1/ -> attributs de Voyage",
+  eq(contextAttributes("R1 := SELECTION(Voyage/dateDep > '2020')\nR2 := RENOMMAGE(R1/", SCHEMA), ["idV", "dateDep", "villeArr"]));
+// JOINTURE : la condition voit les attributs des deux relations.
+check("JOINTURE(Voyage, Reservation/ -> attributs des deux", (() => {
+  const a = contextAttributes("R1 := JOINTURE(Voyage, Reservation/", SCHEMA);
+  return a.includes("dateDep") && a.includes("dateRes");
+})());
+// RENOMMAGE renomme le schéma résultant.
+check("RENOMMAGE renomme le schéma suivi",
+  eq(contextAttributes("R1 := RENOMMAGE(Voyage/villeArr -> destination)\nR2 := SELECTION(R1/", SCHEMA), ["idV", "dateDep", "destination"]));
 
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -1,6 +1,6 @@
 // test-autocomplete.mjs - teste la logique de suggestion contextuelle (pure, sans DOM).
 //   node scripts/test-autocomplete.mjs
-import { suggest, buildAliasMap, algebraAcceptSuffix } from "../templates/web-td/js/autocomplete.js";
+import { suggest, buildAliasMap, algebraAcceptSuffix, completionAction } from "../templates/web-td/js/autocomplete.js";
 
 const SCHEMA = {
   tables: ["Client", "Voyage", "Reservation"],
@@ -76,9 +76,21 @@ check("1re relation UNION -> ', '", algebraAcceptSuffix("UNION(", "table") === "
 check("2e relation JOINTURE -> ' / '", algebraAcceptSuffix("JOINTURE(A, ", "table") === " / ");
 check("2e relation JOINTURE_NATURELLE -> rien", algebraAcceptSuffix("JOINTURE_NATURELLE(A, ", "table") === "");
 
-// ── Algèbre : relation/attribut exact gardé sur appel explicite (Ctrl+Espace) ──
-check("exact relation gardé avec force", suggest("algebra", "SELECTION (VOYAGE", SCHEMA, true).items.some((i) => i.label === "VOYAGE"));
-check("exact relation ignoré sans force", !suggest("algebra", "SELECTION (VOYAGE", SCHEMA, false).items.some((i) => i.label === "VOYAGE"));
+// ── Bug reproduit : sur un nom DÉJÀ complet, ne pas « proposer NUMAV mais insérer -> ».
+//    L'appel explicite doit renvoyer un SÉPARATEUR (insertion directe), jamais une liste
+//    proposant le mot déjà tapé.
+let a = completionAction("algebra", "RENOMMAGE(R1/VILLEARR", SCHEMA, true);
+check("RENOMMAGE + attribut complet -> séparateur ' -> ' (pas de liste)", a.type === "separator" && a.text === " -> ");
+a = completionAction("algebra", "SELECTION(VOYAGE", SCHEMA, true);
+check("SELECTION + relation complète -> séparateur '/'", a.type === "separator" && a.text === "/");
+a = completionAction("algebra", "SELECTION(VOYAGE", SCHEMA, true);
+check("jamais de proposition égale au mot déjà tapé", a.type !== "list" || !a.items.some((i) => i.label === "VOYAGE"));
+a = completionAction("algebra", "SELECTION(VO", SCHEMA, true);
+check("nom partiel -> liste normale (propose VOYAGE)", a.type === "list" && a.items.some((i) => i.label === "VOYAGE"));
+a = completionAction("algebra", "SELECTION(VOYAGE/VILLEARR", SCHEMA, true);
+check("attribut complet sans séparateur (SELECTION) -> rien", a.type === "none");
+a = completionAction("sql", "WHERE ville = 'MAR", SCHEMA, true);
+check("dans une chaîne -> rien (action none)", a.type === "none");
 
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -92,5 +92,14 @@ check("attribut complet sans séparateur (SELECTION) -> rien", a.type === "none"
 a = completionAction("sql", "WHERE ville = 'MAR", SCHEMA, true);
 check("dans une chaîne -> rien (action none)", a.type === "none");
 
+// ── Connecteurs ET/OU/NON : uniquement dans une condition (SELECTION, ET en JOINTURE) ──
+check("RENOMMAGE / -> pas de connecteur", !suggest("algebra", "RENOMMAGE (R1 / ", SCHEMA, true).items.some((i) => i.kind === "kw"));
+check("PROJECTION / -> pas de connecteur", !suggest("algebra", "PROJECTION (R1 / ", SCHEMA, true).items.some((i) => i.kind === "kw"));
+check("SELECTION / -> propose ET", suggest("algebra", "SELECTION (VOYAGE / ", SCHEMA, true).items.some((i) => i.label === "ET"));
+check("JOINTURE / -> propose ET mais pas OU", (() => {
+  const it = suggest("algebra", "JOINTURE (A, B / ", SCHEMA, true).items;
+  return it.some((i) => i.label === "ET") && !it.some((i) => i.label === "OU");
+})());
+
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/scripts/test-autocomplete.mjs
+++ b/scripts/test-autocomplete.mjs
@@ -156,5 +156,14 @@ r = suggest("sql", "SELECT ", SCHEMA, true, "SELECT  FROM Voyage");
 check("SELECT list scopé Voyage -> colonnes de Voyage, pas de Client ni de table",
   labels(r).includes("VILLEARR") && !labels(r).includes("NOM") && !r.items.some((i) => i.kind === "table"));
 
+// ── Après une colonne dans un WHERE : comparateurs + prédicats (pas de colonnes) ──
+r = suggest("sql", "SELECT * FROM Voyage WHERE villeArr ", SCHEMA, true);
+check("WHERE colonne -> comparateurs + IN/LIKE/IS, pas de colonne ni DISTINCT",
+  labels(r).includes("=") && labels(r).includes("IN") && labels(r).includes("IS")
+  && !labels(r).includes("IDV") && !labels(r).includes("DISTINCT"));
+r = suggest("sql", "SELECT * FROM Voyage WHERE ", SCHEMA, true);
+check("WHERE (début) -> colonnes, pas de comparateur",
+  labels(r).includes("VILLEARR") && !labels(r).includes("="));
+
 console.log(`${pass}/${pass + fail} OK - logique d'autocomplétion contextuelle`);
 process.exit(fail === 0 ? 0 : 1);

--- a/templates/web-td/css/style.css
+++ b/templates/web-td/css/style.css
@@ -227,6 +227,6 @@ body {
 .ac-active .ac-kind { color: var(--accent-ink); opacity: .8; }
 .ac-label { overflow: hidden; text-overflow: ellipsis; }
 .ac-kind { font-size: .72rem; color: var(--muted); font-family: system-ui, sans-serif; }
-.ac-kind-table { color: #2f855a; }
+.ac-kind-table, .ac-kind-rel { color: #2f855a; }
 .ac-kind-col { color: var(--accent); }
-@media (prefers-color-scheme: dark) { .ac-kind-table { color: #68d391; } }
+@media (prefers-color-scheme: dark) { .ac-kind-table, .ac-kind-rel { color: #68d391; } }

--- a/templates/web-td/css/style.css
+++ b/templates/web-td/css/style.css
@@ -229,4 +229,5 @@ body {
 .ac-kind { font-size: .72rem; color: var(--muted); font-family: system-ui, sans-serif; }
 .ac-kind-table, .ac-kind-rel { color: #2f855a; }
 .ac-kind-col { color: var(--accent); }
-@media (prefers-color-scheme: dark) { .ac-kind-table, .ac-kind-rel { color: #68d391; } }
+.ac-kind-op { color: #b7791f; }
+@media (prefers-color-scheme: dark) { .ac-kind-table, .ac-kind-rel { color: #68d391; } .ac-kind-op { color: #f6ad55; } }

--- a/templates/web-td/css/style.css
+++ b/templates/web-td/css/style.css
@@ -210,3 +210,23 @@ body {
 .howto-text code { font-family: var(--mono); font-size: .85em; background: var(--bg); padding: .05rem .3rem; border-radius: 4px; }
 .howto-pg-title { font-weight: 700; margin: 1.1rem 0 .2rem; }
 .howto-pg-sub { color: var(--muted); font-size: .85rem; margin: 0 0 .5rem; }
+
+/* Popup d'autocomplétion (positionnée en absolu sur <body>, au niveau du curseur) */
+.ac-popup {
+  position: absolute; z-index: 50; margin: 0; padding: .2rem; list-style: none;
+  min-width: 12rem; max-width: 22rem; max-height: 14rem; overflow-y: auto;
+  background: var(--card); border: 1px solid var(--border); border-radius: 8px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, .18); font-family: var(--mono); font-size: .85rem;
+}
+.ac-item {
+  display: flex; align-items: baseline; justify-content: space-between; gap: .8rem;
+  padding: .25rem .5rem; border-radius: 5px; cursor: pointer; white-space: nowrap;
+}
+.ac-item:hover { background: color-mix(in srgb, var(--accent) 12%, transparent); }
+.ac-active { background: var(--accent); color: var(--accent-ink); }
+.ac-active .ac-kind { color: var(--accent-ink); opacity: .8; }
+.ac-label { overflow: hidden; text-overflow: ellipsis; }
+.ac-kind { font-size: .72rem; color: var(--muted); font-family: system-ui, sans-serif; }
+.ac-kind-table { color: #2f855a; }
+.ac-kind-col { color: var(--accent); }
+@media (prefers-color-scheme: dark) { .ac-kind-table { color: #68d391; } }

--- a/templates/web-td/js/app.js
+++ b/templates/web-td/js/app.js
@@ -1,10 +1,11 @@
 // app.js - interface du TP SQL en ligne.
 
-import { initEngine, runQuery } from "./engine.js";
+import { initEngine, runQuery, getSchema } from "./engine.js";
 import { hashResult } from "./canon.js";
 import { makeStore, buildExport, downloadText, exportFilename } from "./store.js";
 import { highlightSQL, highlightAlgebra } from "./highlight.js";
 import { compileAlgebra, AlgebraError } from "./algebra.js";
+import { attachAutocomplete } from "./autocomplete.js";
 
 const MAX_DISPLAY_ROWS = 50;
 
@@ -382,7 +383,21 @@ function renderQuestion(container, question) {
     highlightPre.scrollTop = textarea.scrollTop;
     highlightPre.scrollLeft = textarea.scrollLeft;
   });
+
+  // Autocomplétion contextuelle : tables/colonnes du schéma + mots-clés (SQL) ou
+  // opérateurs/relations/attributs (algèbre). Déclenchée à la frappe et par Ctrl/Cmd+Espace.
+  const ac = attachAutocomplete(textarea, {
+    getMode: () => mode,
+    getSchema,
+    onInsert: () => {
+      state.answers[question.id] = textarea.value;
+      syncHighlight();
+      saveDebounced();
+    },
+  });
+
   textarea.addEventListener("keydown", (e) => {
+    if (ac.handleKeydown(e)) return; // la popup d'autocomplétion a consommé la touche
     if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
       e.preventDefault();
       run();

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -95,9 +95,53 @@ function algebraCandidates(textBefore, start, schema) {
   let j = start - 1;
   while (j >= 0 && /\s/.test(textBefore[j])) j--;
   const prev = j >= 0 ? textBefore[j] : "";
+  // Après un comparateur ou la flèche « -> » de RENOMMAGE : valeur / nouveau nom (saisie libre).
+  if (prev === ">" || prev === "<" || prev === "=") return [];
   if (prev === "/") return [...cols, { label: "ET", kind: "kw" }, { label: "OU", kind: "kw" }, { label: "NON", kind: "kw" }];
   if (prev === "(" || prev === ",") return [...tables, ...cols];
   return [...ops, ...tables, ...cols];
+}
+
+// Opérateur (et nombre de virgules de premier niveau) de la parenthèse englobant la
+// fin de `before` — pour savoir quel séparateur suit une relation/attribut.
+function enclosingOperator(before) {
+  let depth = 0, openIdx = -1;
+  for (let i = before.length - 1; i >= 0; i--) {
+    if (before[i] === ")") depth++;
+    else if (before[i] === "(") { if (depth === 0) { openIdx = i; break; } depth--; }
+  }
+  if (openIdx < 0) return null;
+  let j = openIdx - 1;
+  while (j >= 0 && /\s/.test(before[j])) j--;
+  const m = /[A-Za-z_]+$/.exec(before.slice(0, j + 1));
+  let commas = 0, d = 0;
+  for (let i = openIdx + 1; i < before.length; i++) {
+    if (before[i] === "(") d++;
+    else if (before[i] === ")") d--;
+    else if (before[i] === "," && d === 0) commas++;
+  }
+  return { op: m ? m[0].toUpperCase() : null, commas };
+}
+
+const AL_UNARY = ["SELECTION", "PROJECTION", "RENOMMAGE"];
+const AL_BINARY = ["UNION", "INTERSECTION", "DIFFERENCE", "JOINTURE", "JOINTURE_NATURELLE", "DIVISION"];
+
+// Séparateur inséré après une relation/attribut accepté en algèbre :
+//   relation d'un opérateur unaire -> « / » ; 1re relation d'un binaire -> « , » ;
+//   2e relation d'une JOINTURE -> « / » ; attribut (ancien nom) dans RENOMMAGE -> « -> ».
+export function algebraAcceptSuffix(before, kind) {
+  const info = enclosingOperator(before);
+  if (!info || !info.op) return "";
+  if (kind === "table") {
+    if (AL_UNARY.includes(info.op)) return "/";
+    if (AL_BINARY.includes(info.op)) {
+      if (info.commas === 0) return ", ";
+      if (info.op === "JOINTURE") return " / ";
+    }
+    return "";
+  }
+  if (kind === "col" && info.op === "RENOMMAGE") return " -> ";
+  return "";
 }
 
 // Vrai si le curseur est dans une chaîne « non fermée » (échappement SQL '' géré).
@@ -132,7 +176,10 @@ export function suggest(mode, textBefore, schema, force = false) {
   for (const it of raw) {
     const low = it.label.toLowerCase();
     if (!low.startsWith(w)) continue;
-    if (low === w && !qualifier) continue; // mot déjà tapé en entier : rien à ajouter
+    // Mot déjà tapé entièrement : rien à ajouter, SAUF (sur appel explicite en algèbre)
+    // une relation/attribut exact, dont l'acceptation insère un séparateur (/, ->, virgule).
+    if (low === w && !qualifier
+        && !(force && mode === "algebra" && (it.kind === "table" || it.kind === "col"))) continue;
     if (seen.has(low)) continue;
     seen.add(low);
     items.push(it);
@@ -219,7 +266,12 @@ export function attachAutocomplete(textarea, opts) {
   function accept(i) {
     if (i < 0 || i >= items.length) return;
     const pos = textarea.selectionStart;
-    const insert = items[i].label;
+    let insert = items[i].label;
+    // En algèbre, insérer une relation/attribut ajoute le séparateur attendu (/, ->, virgule),
+    // de sorte que l'appel de complétion suivant propose la suite (attributs, nouveau nom...).
+    if (opts.getMode() === "algebra") {
+      insert += algebraAcceptSuffix(textarea.value.slice(0, anchorStart), items[i].kind);
+    }
     textarea.value = textarea.value.slice(0, anchorStart) + insert + textarea.value.slice(pos);
     textarea.selectionStart = textarea.selectionEnd = anchorStart + insert.length;
     close();

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -62,6 +62,21 @@ function resolveTable(qualifier, sql, schema) {
   return (schema.tables || []).find((t) => t.toLowerCase() === target) || null;
 }
 
+// Colonnes des tables présentes dans le FROM/JOIN de la requête (null si aucun FROM).
+function inScopeColumns(sql, schema) {
+  const inScope = new Set(Object.values(buildAliasMap(sql)).map((t) => t.toLowerCase()));
+  if (!inScope.size) return null;
+  const cols = [], seen = new Set();
+  for (const t of (schema.tables || [])) {
+    if (!inScope.has(t.toLowerCase())) continue;
+    for (const c of (schema.columns[t] || [])) {
+      const k = c.toLowerCase();
+      if (!seen.has(k)) { seen.add(k); cols.push(c); }
+    }
+  }
+  return cols.length ? cols : null;
+}
+
 function lastClauseKeyword(text) {
   let last = null, m;
   CLAUSE_KW.lastIndex = 0;
@@ -74,17 +89,19 @@ function lastClauseKeyword(text) {
 const upTables = (schema) => (schema.tables || []).map((x) => ({ label: x.toUpperCase(), kind: "table" }));
 const upCols = (list) => (list || []).map((x) => ({ label: x.toUpperCase(), kind: "col" }));
 
-function sqlCandidates(textBefore, start, qualifier, schema) {
+function sqlCandidates(textBefore, start, qualifier, schema, fullText) {
+  const src = fullText || textBefore; // le FROM peut être APRÈS le curseur (liste du SELECT)
   const tables = upTables(schema);
-  const cols = upCols(schema.allColumns);
   const kw = [...SQL_KEYWORDS, ...SQL_FUNCTIONS].map((x) => ({ label: x, kind: "kw" }));
   if (qualifier) {
-    const table = resolveTable(qualifier, textBefore, schema);
+    const table = resolveTable(qualifier, src, schema);
     const list = table && schema.columns[table] ? schema.columns[table] : (schema.allColumns || []);
     return upCols(list);
   }
   const ctx = lastClauseKeyword(textBefore.slice(0, start));
   if (ctx === "FROM" || ctx === "JOIN") return [...tables, ...kw];
+  // Colonnes non qualifiées : restreintes aux tables du FROM/JOIN si connu, sinon toutes.
+  const cols = upCols(inScopeColumns(src, schema) || schema.allColumns);
   return [...cols, ...tables, ...kw];
 }
 
@@ -286,13 +303,13 @@ export function pendingSeparator(textBefore, schema) {
 // Décision d'un déclenchement de complétion, testable sans DOM :
 //   { type:"separator", text } : insère directement le séparateur (nom déjà complet) ;
 //   { type:"list", start, word, items } : affiche la popup ; { type:"none" }.
-export function completionAction(mode, textBefore, schema, force = false) {
+export function completionAction(mode, textBefore, schema, force = false, fullText = null) {
   if (inString(textBefore)) return { type: "none" };
   if (force && mode === "algebra") {
     const sep = pendingSeparator(textBefore, schema);
     if (sep) return { type: "separator", text: sep };
   }
-  const res = suggest(mode, textBefore, schema, force);
+  const res = suggest(mode, textBefore, schema, force, fullText);
   if (!res.items.length) return { type: "none" };
   return { type: "list", start: res.start, word: res.word, items: res.items };
 }
@@ -309,7 +326,7 @@ function inString(text) {
 }
 
 // Renvoie { start, word, items:[{label, kind}] } ; items filtrés par préfixe (casse ignorée).
-export function suggest(mode, textBefore, schema, force = false) {
+export function suggest(mode, textBefore, schema, force = false, fullText = null) {
   if (inString(textBefore)) return { start: textBefore.length, word: "", items: [] };
   const wm = TRAILING_WORD.exec(textBefore);
   const word = wm ? wm[0] : "";
@@ -322,7 +339,7 @@ export function suggest(mode, textBefore, schema, force = false) {
   if (!force && !qualifier && word.length < 1) return { start, word, items: [] };
   const raw = mode === "algebra"
     ? algebraCandidates(textBefore, start, schema)
-    : sqlCandidates(textBefore, start, qualifier, schema);
+    : sqlCandidates(textBefore, start, qualifier, schema, fullText);
   const w = word.toLowerCase();
   const seen = new Set();
   const items = [];
@@ -405,7 +422,7 @@ export function attachAutocomplete(textarea, opts) {
   function update(force = false) {
     if (textarea.selectionStart !== textarea.selectionEnd) return close();
     const pos = textarea.selectionStart;
-    const act = completionAction(opts.getMode(), textarea.value.slice(0, pos), opts.getSchema(), force);
+    const act = completionAction(opts.getMode(), textarea.value.slice(0, pos), opts.getSchema(), force, textarea.value);
     if (act.type === "none") return close();
     if (act.type === "separator") {
       // Nom déjà complet : on insère directement le séparateur, sans proposer le mot lui-même.

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -144,6 +144,40 @@ export function algebraAcceptSuffix(before, kind) {
   return "";
 }
 
+// Sur appel explicite (Ctrl+Espace) : si le mot sous le curseur est une relation/attribut
+// DÉJÀ complet, à une position où un séparateur suit, renvoie ce séparateur (sinon "").
+export function pendingSeparator(textBefore, schema) {
+  const wm = TRAILING_WORD.exec(textBefore);
+  if (!wm) return "";
+  const word = wm[0];
+  const start = textBefore.length - word.length;
+  let j = start - 1;
+  while (j >= 0 && /\s/.test(textBefore[j])) j--;
+  const prev = j >= 0 ? textBefore[j] : "";
+  let kind = null;
+  if (prev === "(" || prev === ",") kind = "table";
+  else if (prev === "/") kind = "col";
+  else return "";
+  const wl = word.toLowerCase();
+  const list = kind === "table" ? (schema.tables || []) : (schema.allColumns || []);
+  if (!list.some((x) => x.toLowerCase() === wl)) return "";
+  return algebraAcceptSuffix(textBefore.slice(0, start), kind);
+}
+
+// Décision d'un déclenchement de complétion, testable sans DOM :
+//   { type:"separator", text } : insère directement le séparateur (nom déjà complet) ;
+//   { type:"list", start, word, items } : affiche la popup ; { type:"none" }.
+export function completionAction(mode, textBefore, schema, force = false) {
+  if (inString(textBefore)) return { type: "none" };
+  if (force && mode === "algebra") {
+    const sep = pendingSeparator(textBefore, schema);
+    if (sep) return { type: "separator", text: sep };
+  }
+  const res = suggest(mode, textBefore, schema, force);
+  if (!res.items.length) return { type: "none" };
+  return { type: "list", start: res.start, word: res.word, items: res.items };
+}
+
 // Vrai si le curseur est dans une chaîne « non fermée » (échappement SQL '' géré).
 function inString(text) {
   let inStr = false;
@@ -176,10 +210,7 @@ export function suggest(mode, textBefore, schema, force = false) {
   for (const it of raw) {
     const low = it.label.toLowerCase();
     if (!low.startsWith(w)) continue;
-    // Mot déjà tapé entièrement : rien à ajouter, SAUF (sur appel explicite en algèbre)
-    // une relation/attribut exact, dont l'acceptation insère un séparateur (/, ->, virgule).
-    if (low === w && !qualifier
-        && !(force && mode === "algebra" && (it.kind === "table" || it.kind === "col"))) continue;
+    if (low === w && !qualifier) continue; // mot déjà tapé en entier : rien à proposer
     if (seen.has(low)) continue;
     seen.add(low);
     items.push(it);
@@ -255,9 +286,17 @@ export function attachAutocomplete(textarea, opts) {
   function update(force = false) {
     if (textarea.selectionStart !== textarea.selectionEnd) return close();
     const pos = textarea.selectionStart;
-    const res = suggest(opts.getMode(), textarea.value.slice(0, pos), opts.getSchema(), force);
-    if (!res.items.length) return close();
-    items = res.items; anchorStart = res.start; active = 0;
+    const act = completionAction(opts.getMode(), textarea.value.slice(0, pos), opts.getSchema(), force);
+    if (act.type === "none") return close();
+    if (act.type === "separator") {
+      // Nom déjà complet : on insère directement le séparateur, sans proposer le mot lui-même.
+      textarea.value = textarea.value.slice(0, pos) + act.text + textarea.value.slice(pos);
+      textarea.selectionStart = textarea.selectionEnd = pos + act.text.length;
+      close();
+      if (opts.onInsert) opts.onInsert();
+      return;
+    }
+    items = act.items; anchorStart = act.start; active = 0;
     render();
     popup.style.display = "block";
     position();

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -97,7 +97,15 @@ function algebraCandidates(textBefore, start, schema) {
   const prev = j >= 0 ? textBefore[j] : "";
   // Après un comparateur ou la flèche « -> » de RENOMMAGE : valeur / nouveau nom (saisie libre).
   if (prev === ">" || prev === "<" || prev === "=") return [];
-  if (prev === "/") return [...cols, { label: "ET", kind: "kw" }, { label: "OU", kind: "kw" }, { label: "NON", kind: "kw" }];
+  if (prev === "/") {
+    // Après « / » : des attributs. Les connecteurs ET/OU/NON ne s'appliquent qu'à la
+    // CONDITION d'une SELECTION (ET seul dans une JOINTURE) ; pas à la liste d'attributs
+    // d'une PROJECTION ni aux renommages d'un RENOMMAGE.
+    const op = (enclosingOperator(textBefore.slice(0, start)) || {}).op;
+    if (op === "SELECTION") return [...cols, { label: "ET", kind: "kw" }, { label: "OU", kind: "kw" }, { label: "NON", kind: "kw" }];
+    if (op === "JOINTURE") return [...cols, { label: "ET", kind: "kw" }];
+    return cols;
+  }
   if (prev === "(" || prev === ",") return [...tables, ...cols];
   return [...ops, ...tables, ...cols];
 }

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -100,8 +100,17 @@ function algebraCandidates(textBefore, start, schema) {
   const prev = j >= 0 ? textBefore[j] : "";
   // Après un comparateur ou la flèche « -> » de RENOMMAGE : valeur / nouveau nom (saisie libre).
   if (prev === ">" || prev === "<" || prev === "=") return [];
-  if (prev === "/") return cols; // début de condition / liste d'attributs / renommage -> attributs
-  if (prev === "(" || prev === ",") return [...tables, ...cols];
+  if (prev === "/") {
+    // Attributs de la relation en cours (pas toutes les tables) ; repli si indéterminé.
+    const attrs = contextAttributes(before, schema);
+    const list = attrs && attrs.length ? attrs : (schema.allColumns || []);
+    return list.map((x) => ({ label: x.toUpperCase(), kind: "col" }));
+  }
+  if (prev === "(" || prev === ",") {
+    // Opérande : relation de base OU relation intermédiaire (Rn) déjà définie.
+    const rels = definedRelations(before, schema).names.map((n) => ({ label: n.toUpperCase(), kind: "rel" }));
+    return [...tables, ...rels];
+  }
   return [...ops, ...tables, ...cols];
 }
 
@@ -123,7 +132,114 @@ function enclosingOperator(before) {
     else if (before[i] === ")") d--;
     else if (before[i] === "," && d === 0) commas++;
   }
-  return { op: m ? m[0].toUpperCase() : null, commas };
+  return { op: m ? m[0].toUpperCase() : null, commas, openIdx };
+}
+
+// ── Suivi du schéma des relations (pour proposer les attributs du bon opérande) ──
+
+function topLevelIndex(s, ch) {
+  let depth = 0, inStr = false;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) { if (c === "'") { if (s[i + 1] === "'") { i++; continue; } inStr = false; } }
+    else if (c === "'") inStr = true;
+    else if (c === "(") depth++;
+    else if (c === ")") depth--;
+    else if (c === ch && depth === 0) return i;
+  }
+  return -1;
+}
+
+function splitTopLevel(s, ch) {
+  const parts = [];
+  let depth = 0, inStr = false, last = 0;
+  for (let i = 0; i < s.length; i++) {
+    const c = s[i];
+    if (inStr) { if (c === "'") { if (s[i + 1] === "'") { i++; continue; } inStr = false; } }
+    else if (c === "'") inStr = true;
+    else if (c === "(") depth++;
+    else if (c === ")") depth--;
+    else if (c === ch && depth === 0) { parts.push(s.slice(last, i)); last = i + 1; }
+  }
+  parts.push(s.slice(last));
+  return parts;
+}
+
+// Colonnes d'une relation : table de base OU relation intermédiaire déjà définie.
+function relationSchema(name, rels, baseSchema) {
+  if (!name) return null;
+  const nl = name.trim().toLowerCase();
+  if (rels[nl]) return rels[nl];
+  const t = (baseSchema.tables || []).find((x) => x.toLowerCase() === nl);
+  return t ? (baseSchema.columns[t] || []) : null;
+}
+
+// Schéma résultant d'une expression algébrique (approché, pour l'autocomplétion).
+function exprSchema(expr, rels, baseSchema) {
+  const m = /^\s*([A-Za-z_]+)\s*\(([\s\S]*)\)\s*$/.exec(expr);
+  if (!m) {
+    const nm = /^\s*([A-Za-z_][\w.'-]*)\s*$/.exec(expr);
+    return nm ? relationSchema(nm[1], rels, baseSchema) : null;
+  }
+  const op = m[1].toUpperCase();
+  const inner = m[2];
+  const slash = topLevelIndex(inner, "/");
+  const operandsPart = slash >= 0 ? inner.slice(0, slash) : inner;
+  const rest = slash >= 0 ? inner.slice(slash + 1) : "";
+  const operands = splitTopLevel(operandsPart, ",").map((s) => s.trim()).filter(Boolean);
+  const sch = (n) => relationSchema(n, rels, baseSchema) || [];
+  if (op === "SELECTION") return sch(operands[0]);
+  if (op === "PROJECTION") return splitTopLevel(rest, ",").map((s) => s.trim()).filter(Boolean);
+  if (op === "RENOMMAGE") {
+    const renames = {};
+    for (const pair of splitTopLevel(rest, ",")) {
+      const pm = /([A-Za-z_]\w*)\s*->\s*([A-Za-z_]\w*)/.exec(pair);
+      if (pm) renames[pm[1].toLowerCase()] = pm[2];
+    }
+    return sch(operands[0]).map((c) => renames[c.toLowerCase()] || c);
+  }
+  if (op === "UNION" || op === "INTERSECTION" || op === "DIFFERENCE") return sch(operands[0]);
+  if (op === "JOINTURE") return [...sch(operands[0]), ...sch(operands[1])];
+  if (op === "JOINTURE_NATURELLE") {
+    const a = sch(operands[0]), b = sch(operands[1]);
+    const seen = new Set(a.map((c) => c.toLowerCase()));
+    return [...a, ...b.filter((c) => !seen.has(c.toLowerCase()))];
+  }
+  if (op === "DIVISION") {
+    const rm = new Set(sch(operands[1]).map((c) => c.toLowerCase()));
+    return sch(operands[0]).filter((c) => !rm.has(c.toLowerCase()));
+  }
+  return null;
+}
+
+// Relations intermédiaires définies avant la ligne courante : { schemas:{lower:cols}, names:[] }.
+function definedRelations(textBefore, baseSchema) {
+  const schemas = {}, names = [];
+  const lines = textBefore.split("\n");
+  for (let i = 0; i < lines.length - 1; i++) { // sauf la ligne en cours de frappe
+    const am = /^\s*([A-Za-z_][\w.'-]*)\s*:=\s*([\s\S]+)$/.exec(lines[i]);
+    if (!am) continue;
+    const sch = exprSchema(am[2], schemas, baseSchema);
+    if (sch) schemas[am[1].toLowerCase()] = sch;
+    names.push(am[1]);
+  }
+  return { schemas, names };
+}
+
+// Attributs disponibles à l'endroit du curseur (après « / »), = schéma du/des opérande(s)
+// de l'opérateur courant. null si indéterminé (→ repli sur toutes les colonnes).
+export function contextAttributes(textBefore, baseSchema) {
+  const { schemas } = definedRelations(textBefore, baseSchema);
+  const info = enclosingOperator(textBefore);
+  if (!info || info.openIdx < 0) return null;
+  const afterOpen = textBefore.slice(info.openIdx + 1);
+  const slash = topLevelIndex(afterOpen, "/");
+  const operandsPart = slash >= 0 ? afterOpen.slice(0, slash) : afterOpen;
+  const operands = splitTopLevel(operandsPart, ",").map((s) => s.trim()).filter(Boolean);
+  const sch = (n) => relationSchema(n, schemas, baseSchema) || [];
+  // JOINTURE : la condition peut porter sur les attributs des DEUX relations.
+  if (info.op === "JOINTURE") return [...sch(operands[0]), ...sch(operands[1])];
+  return sch(operands[0]);
 }
 
 const AL_UNARY = ["SELECTION", "PROJECTION", "RENOMMAGE"];
@@ -224,7 +340,7 @@ export function suggest(mode, textBefore, schema, force = false) {
 
 // ── Popup (DOM) ──────────────────────────────────────────────────────────────
 
-const KIND_LABEL = { table: "table", col: "colonne", kw: "mot-clé" };
+const KIND_LABEL = { table: "table", rel: "relation", col: "colonne", kw: "mot-clé" };
 
 // Coordonnées (px) du curseur dans le textarea, via un div-miroir.
 function caretCoords(textarea, position) {

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -19,6 +19,12 @@ const SQL_KEYWORDS = [
 ];
 const SQL_FUNCTIONS = ["COUNT", "SUM", "AVG", "MIN", "MAX", "ROUND", "COALESCE",
   "UPPER", "LOWER", "LENGTH", "SUBSTR"];
+// Dans la clause FROM : après FROM/JOIN/virgule on attend une TABLE ; après un nom de
+// table on propose les mots-clés de jointure / la clause suivante (pas SELECT, WHERE placé
+// ici pour enchaîner). Évite de noyer la liste des tables sous tous les mots-clés.
+const SQL_TABLE_EXPECTING = ["FROM", "JOIN", ","];
+const SQL_AFTER_TABLE = ["JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "CROSS",
+  "NATURAL", "ON", "WHERE", "GROUP", "ORDER", "HAVING"];
 // Opérateurs relationnels seulement (proposés en début d'expression). Les connecteurs
 // ET/OU/NON ne sont PAS complétés : ils ne peuvent pas ouvrir une condition (on commence
 // par un attribut) et sont assez courts pour être tapés à la main.
@@ -84,6 +90,13 @@ function lastClauseKeyword(text) {
   return last;
 }
 
+// Dernier jeton avant le mot en cours : identifiant (MAJ) ou ponctuation (« , » « ( »…).
+function prevToken(textBeforeWord) {
+  const t = textBeforeWord.replace(/\s+$/, "");
+  const wm = /[A-Za-z_][A-Za-z0-9_]*$/.exec(t);
+  return wm ? wm[0].toUpperCase() : t.slice(-1);
+}
+
 // Relations et attributs proposés en MAJUSCULES (SQLite et le compilateur d'algèbre
 // sont insensibles à la casse) ; les mots-clés/opérateurs sont déjà en majuscules.
 const upTables = (schema) => (schema.tables || []).map((x) => ({ label: x.toUpperCase(), kind: "table" }));
@@ -99,7 +112,12 @@ function sqlCandidates(textBefore, start, qualifier, schema, fullText) {
     return upCols(list);
   }
   const ctx = lastClauseKeyword(textBefore.slice(0, start));
-  if (ctx === "FROM" || ctx === "JOIN") return [...tables, ...kw];
+  if (ctx === "FROM" || ctx === "JOIN") {
+    const pt = prevToken(textBefore.slice(0, start));
+    // Après FROM/JOIN/virgule -> une table ; après un nom de table -> mots-clés de jointure.
+    if (SQL_TABLE_EXPECTING.includes(pt)) return tables;
+    return SQL_AFTER_TABLE.map((x) => ({ label: x, kind: "kw" }));
+  }
   // Colonnes non qualifiées : restreintes aux tables du FROM/JOIN si connu, sinon toutes.
   const cols = upCols(inScopeColumns(src, schema) || schema.allColumns);
   return [...cols, ...tables, ...kw];

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -29,9 +29,13 @@ const SQL_AFTER_TABLE = ["JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "CRO
 // opérateurs, mais PAS les démarreurs de clause (SELECT/FROM/WHERE/GROUP...).
 const SQL_EXPR_KW = ["DISTINCT", "AS", "AND", "OR", "NOT", "IN", "EXISTS", "IS", "NULL",
   "LIKE", "BETWEEN", "CASE", "WHEN", "THEN", "ELSE", "END"];
-// Après une COLONNE dans une condition (WHERE/ON/HAVING) : comparateurs + prédicats.
+// Dans une condition (WHERE/ON/HAVING) : après un opérande (colonne ou agrégat) ->
+// comparateurs + prédicats ; après une valeur -> connecteurs logiques.
 const SQL_COMPARATORS = ["=", "<>", "<", ">", "<=", ">="];
 const SQL_PREDICATE_KW = ["IN", "LIKE", "BETWEEN", "IS", "NOT"];
+const SQL_CONNECTORS = ["AND", "OR"];
+// Expression se terminant par un appel de fonction FONC(...) (agrégat ou scalaire).
+const SQL_FUNC_END = /\b(COUNT|SUM|AVG|MIN|MAX|ROUND|COALESCE|LENGTH|SUBSTR|UPPER|LOWER)\s*\([^()]*\)$/i;
 // Opérateurs relationnels seulement (proposés en début d'expression). Les connecteurs
 // ET/OU/NON ne sont PAS complétés : ils ne peuvent pas ouvrir une condition (on commence
 // par un attribut) et sont assez courts pour être tapés à la main.
@@ -130,19 +134,34 @@ function sqlCandidates(textBefore, start, qualifier, schema, fullText) {
     if (SQL_TABLE_EXPECTING.includes(pt)) return upTables(schema);
     return SQL_AFTER_TABLE.map((x) => ({ label: x, kind: "kw" }));
   }
-  // Après une colonne dans une condition -> comparateurs + prédicats (IN, LIKE, IS...).
-  if ((ctx === "WHERE" || ctx === "ON" || ctx === "HAVING")
-      && isInScopeColumn(prevToken(textBefore.slice(0, start)), src, schema)) {
-    return [
-      ...SQL_COMPARATORS.map((x) => ({ label: x, kind: "op" })),
-      ...SQL_PREDICATE_KW.map((x) => ({ label: x, kind: "kw" })),
-    ];
+  const scopedCols = () => upCols(inScopeColumns(src, schema) || schema.allColumns);
+  const beforeCur = textBefore.slice(0, start);
+  const pt = prevToken(beforeCur);
+
+  // Conditions (WHERE / ON / HAVING).
+  if (ctx === "WHERE" || ctx === "ON" || ctx === "HAVING") {
+    // Après un opérande (colonne ou fin d'agrégat/fonction) -> comparateur / prédicat.
+    if (isInScopeColumn(pt, src, schema) || SQL_FUNC_END.test(beforeCur.replace(/\s+$/, ""))) {
+      return [...SQL_COMPARATORS.map((x) => ({ label: x, kind: "op" })),
+              ...SQL_PREDICATE_KW.map((x) => ({ label: x, kind: "kw" }))];
+    }
+    // Après une valeur (chaîne, nombre, NULL) -> connecteurs logiques.
+    if (pt === "'" || pt === "NULL" || /^[0-9]/.test(pt)) {
+      return SQL_CONNECTORS.map((x) => ({ label: x, kind: "kw" }));
+    }
+    // Sinon (début, après opérateur/AND/OR...) -> opérande : colonnes + fonctions.
+    return [...scopedCols(), ...SQL_FUNCTIONS.map((x) => ({ label: x, kind: "kw" }))];
   }
-  // Position d'expression (SELECT, WHERE, GROUP BY, ON...) : colonnes (restreintes aux
-  // tables du FROM) + fonctions + mots-clés d'expression. Pas de tables ni de clause.
-  const cols = upCols(inScopeColumns(src, schema) || schema.allColumns);
+
+  // GROUP BY / ORDER BY : colonnes + fonctions + ASC/DESC (pas DISTINCT/AS/connecteurs).
+  if (ctx === "BY") {
+    const kw = [...SQL_FUNCTIONS, "ASC", "DESC"].map((x) => ({ label: x, kind: "kw" }));
+    return [...scopedCols(), ...kw];
+  }
+
+  // SELECT et autres positions d'expression : colonnes + fonctions + mots-clés d'expression.
   const kw = [...SQL_FUNCTIONS, ...SQL_EXPR_KW].map((x) => ({ label: x, kind: "kw" }));
-  return [...cols, ...kw];
+  return [...scopedCols(), ...kw];
 }
 
 function algebraCandidates(textBefore, start, schema) {

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -19,9 +19,12 @@ const SQL_KEYWORDS = [
 ];
 const SQL_FUNCTIONS = ["COUNT", "SUM", "AVG", "MIN", "MAX", "ROUND", "COALESCE",
   "UPPER", "LOWER", "LENGTH", "SUBSTR"];
+// Opérateurs relationnels seulement (proposés en début d'expression). Les connecteurs
+// ET/OU/NON ne sont PAS complétés : ils ne peuvent pas ouvrir une condition (on commence
+// par un attribut) et sont assez courts pour être tapés à la main.
 const ALGEBRA_OPERATORS = [
   "SELECTION", "PROJECTION", "RENOMMAGE", "UNION", "INTERSECTION", "DIFFERENCE",
-  "JOINTURE", "JOINTURE_NATURELLE", "DIVISION", "ET", "OU", "NON",
+  "JOINTURE", "JOINTURE_NATURELLE", "DIVISION",
 ];
 
 const IDENT = "[A-Za-z_\\u00C0-\\u024F][A-Za-z0-9_\\u00C0-\\u024F]*";
@@ -97,15 +100,7 @@ function algebraCandidates(textBefore, start, schema) {
   const prev = j >= 0 ? textBefore[j] : "";
   // Après un comparateur ou la flèche « -> » de RENOMMAGE : valeur / nouveau nom (saisie libre).
   if (prev === ">" || prev === "<" || prev === "=") return [];
-  if (prev === "/") {
-    // Après « / » : des attributs. Les connecteurs ET/OU/NON ne s'appliquent qu'à la
-    // CONDITION d'une SELECTION (ET seul dans une JOINTURE) ; pas à la liste d'attributs
-    // d'une PROJECTION ni aux renommages d'un RENOMMAGE.
-    const op = (enclosingOperator(textBefore.slice(0, start)) || {}).op;
-    if (op === "SELECTION") return [...cols, { label: "ET", kind: "kw" }, { label: "OU", kind: "kw" }, { label: "NON", kind: "kw" }];
-    if (op === "JOINTURE") return [...cols, { label: "ET", kind: "kw" }];
-    return cols;
-  }
+  if (prev === "/") return cols; // début de condition / liste d'attributs / renommage -> attributs
   if (prev === "(" || prev === ",") return [...tables, ...cols];
   return [...ops, ...tables, ...cols];
 }

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -34,8 +34,7 @@ const SQL_EXPR_KW = ["DISTINCT", "AS", "AND", "OR", "NOT", "IN", "EXISTS", "IS",
 const SQL_COMPARATORS = ["=", "<>", "<", ">", "<=", ">="];
 const SQL_PREDICATE_KW = ["IN", "LIKE", "BETWEEN", "IS", "NOT"];
 const SQL_CONNECTORS = ["AND", "OR"];
-// Expression se terminant par un appel de fonction FONC(...) (agrégat ou scalaire).
-const SQL_FUNC_END = /\b(COUNT|SUM|AVG|MIN|MAX|ROUND|COALESCE|LENGTH|SUBSTR|UPPER|LOWER)\s*\([^()]*\)$/i;
+const SQL_FUNCS_SET = new Set(SQL_FUNCTIONS);
 // Opérateurs relationnels seulement (proposés en début d'expression). Les connecteurs
 // ET/OU/NON ne sont PAS complétés : ils ne peuvent pas ouvrir une condition (on commence
 // par un attribut) et sont assez courts pour être tapés à la main.
@@ -46,11 +45,11 @@ const ALGEBRA_OPERATORS = [
 
 const IDENT = "[A-Za-z_\\u00C0-\\u024F][A-Za-z0-9_\\u00C0-\\u024F]*";
 const TRAILING_WORD = new RegExp(IDENT + "$");
-// FROM/JOIN font passer en « contexte tables » ; toute autre clause plus récente
-// repasse en « contexte colonnes » (la virgule n'est pas un mot-clé, donc « FROM a, » reste tables).
+// Démarreurs de CLAUSE uniquement (pas les opérateurs AND/OR/IN/LIKE...) : lastClauseKeyword
+// doit donner la clause qui gouverne le curseur (WHERE...), pas le dernier opérateur tapé.
 const CLAUSE_KW = new RegExp(
-  "\\b(SELECT|FROM|WHERE|JOIN|ON|GROUP|ORDER|HAVING|BY|AND|OR|NOT|IN|LIKE|BETWEEN|" +
-  "SET|VALUES|UNION|EXCEPT|INTERSECT|AS|WITH|USING|CASE|WHEN|THEN|ELSE)\\b", "gi");
+  "\\b(SELECT|FROM|WHERE|JOIN|ON|GROUP|ORDER|HAVING|BY|SET|VALUES|UNION|EXCEPT|INTERSECT|WITH)\\b",
+  "gi");
 
 // ── Logique de suggestion (pure) ─────────────────────────────────────────────
 
@@ -101,6 +100,52 @@ function isInScopeColumn(name, sql, schema) {
   return scoped.some((c) => c.toLowerCase() === nl);
 }
 
+// Le texte se termine-t-il par un appel de fonction FONC(...) (agrégat/scalaire) ?
+// Distingue « COUNT(*) » (opérande) de « IN (...) » / « (a OR b) » (prédicat/groupe fermé).
+function closesFunctionCall(text) {
+  const t = text.replace(/\s+$/, "");
+  if (!t.endsWith(")")) return false;
+  let depth = 0;
+  for (let i = t.length - 1; i >= 0; i--) {
+    if (t[i] === ")") depth++;
+    else if (t[i] === "(") {
+      depth--;
+      if (depth === 0) {
+        const fm = /[A-Za-z_][A-Za-z0-9_]*$/.exec(t.slice(0, i).replace(/\s+$/, ""));
+        return fm ? SQL_FUNCS_SET.has(fm[0].toUpperCase()) : false;
+      }
+    }
+  }
+  return false;
+}
+
+// Texte des niveaux de requête ENGLOBANT le curseur : retire les (...) « sœurs »
+// (équilibrées, ne contenant pas le curseur) pour ne pas mélanger les portées d'un
+// sous-requête sœur avec la requête courante. Conserve les niveaux englobants.
+function scopeText(text, cursor) {
+  let out = "", i = 0;
+  while (i < text.length) {
+    if (text[i] === "(") {
+      let depth = 0, j = i;
+      for (; j < text.length; j++) {
+        if (text[j] === "(") depth++;
+        else if (text[j] === ")") { depth--; if (depth === 0) break; }
+      }
+      const close = j < text.length ? j : text.length; // ')' ou fin si non équilibré
+      if (cursor > i && cursor <= close) {
+        out += " " + scopeText(text.slice(i + 1, close), cursor - (i + 1)); // curseur dedans
+      } else {
+        out += " "; // groupe sœur -> retiré
+      }
+      i = close + 1;
+    } else {
+      out += text[i];
+      i++;
+    }
+  }
+  return out;
+}
+
 function lastClauseKeyword(text) {
   let last = null, m;
   CLAUSE_KW.lastIndex = 0;
@@ -122,31 +167,35 @@ const upCols = (list) => (list || []).map((x) => ({ label: x.toUpperCase(), kind
 
 function sqlCandidates(textBefore, start, qualifier, schema, fullText) {
   const src = fullText || textBefore; // le FROM peut être APRÈS le curseur (liste du SELECT)
+  // Portée : uniquement les niveaux de requête englobant le curseur (pas les sous-requêtes sœurs).
+  const scope = scopeText(src, textBefore.length);
   if (qualifier) {
-    const table = resolveTable(qualifier, src, schema);
+    const table = resolveTable(qualifier, scope, schema);
     const list = table && schema.columns[table] ? schema.columns[table] : (schema.allColumns || []);
     return upCols(list);
   }
-  const ctx = lastClauseKeyword(textBefore.slice(0, start));
+  const beforeCur = textBefore.slice(0, start);
+  // Contexte de clause déterminé au niveau ENGLOBANT (sous-requêtes sœurs retirées), sinon
+  // un FROM de sous-requête fausserait le contexte de la requête courante.
+  const ctx = lastClauseKeyword(scopeText(beforeCur, beforeCur.length));
+  const pt = prevToken(beforeCur); // brut : voit le ')' d'une sous-requête / d'une fonction
   if (ctx === "FROM" || ctx === "JOIN") {
-    const pt = prevToken(textBefore.slice(0, start));
     // Après FROM/JOIN/virgule -> une table ; après un nom de table -> mots-clés de jointure.
     if (SQL_TABLE_EXPECTING.includes(pt)) return upTables(schema);
     return SQL_AFTER_TABLE.map((x) => ({ label: x, kind: "kw" }));
   }
-  const scopedCols = () => upCols(inScopeColumns(src, schema) || schema.allColumns);
-  const beforeCur = textBefore.slice(0, start);
-  const pt = prevToken(beforeCur);
+  const scopedCols = () => upCols(inScopeColumns(scope, schema) || schema.allColumns);
 
   // Conditions (WHERE / ON / HAVING).
   if (ctx === "WHERE" || ctx === "ON" || ctx === "HAVING") {
-    // Après un opérande (colonne ou fin d'agrégat/fonction) -> comparateur / prédicat.
-    if (isInScopeColumn(pt, src, schema) || SQL_FUNC_END.test(beforeCur.replace(/\s+$/, ""))) {
+    // Après un opérande (colonne ou fin d'appel de fonction) -> comparateur / prédicat.
+    if (isInScopeColumn(pt, scope, schema) || closesFunctionCall(beforeCur)) {
       return [...SQL_COMPARATORS.map((x) => ({ label: x, kind: "op" })),
               ...SQL_PREDICATE_KW.map((x) => ({ label: x, kind: "kw" }))];
     }
-    // Après une valeur (chaîne, nombre, NULL) -> connecteurs logiques.
-    if (pt === "'" || pt === "NULL" || /^[0-9]/.test(pt)) {
+    // Après une valeur, ou une parenthèse fermante non-fonction (fin de IN(...) / sous-requête
+    // / sous-condition) -> connecteurs logiques AND/OR.
+    if (pt === "'" || pt === "NULL" || /^[0-9]/.test(pt) || pt === ")") {
       return SQL_CONNECTORS.map((x) => ({ label: x, kind: "kw" }));
     }
     // Sinon (début, après opérateur/AND/OR...) -> opérande : colonnes + fonctions.

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -104,8 +104,6 @@ const upCols = (list) => (list || []).map((x) => ({ label: x.toUpperCase(), kind
 
 function sqlCandidates(textBefore, start, qualifier, schema, fullText) {
   const src = fullText || textBefore; // le FROM peut être APRÈS le curseur (liste du SELECT)
-  const tables = upTables(schema);
-  const kw = [...SQL_KEYWORDS, ...SQL_FUNCTIONS].map((x) => ({ label: x, kind: "kw" }));
   if (qualifier) {
     const table = resolveTable(qualifier, src, schema);
     const list = table && schema.columns[table] ? schema.columns[table] : (schema.allColumns || []);
@@ -115,12 +113,14 @@ function sqlCandidates(textBefore, start, qualifier, schema, fullText) {
   if (ctx === "FROM" || ctx === "JOIN") {
     const pt = prevToken(textBefore.slice(0, start));
     // Après FROM/JOIN/virgule -> une table ; après un nom de table -> mots-clés de jointure.
-    if (SQL_TABLE_EXPECTING.includes(pt)) return tables;
+    if (SQL_TABLE_EXPECTING.includes(pt)) return upTables(schema);
     return SQL_AFTER_TABLE.map((x) => ({ label: x, kind: "kw" }));
   }
-  // Colonnes non qualifiées : restreintes aux tables du FROM/JOIN si connu, sinon toutes.
+  // Position d'expression (SELECT, WHERE, GROUP BY, ON...) : colonnes (restreintes aux
+  // tables du FROM) + fonctions. Pas de tables ni de mots-clés de clause (bruit).
   const cols = upCols(inScopeColumns(src, schema) || schema.allColumns);
-  return [...cols, ...tables, ...kw];
+  const fns = SQL_FUNCTIONS.map((x) => ({ label: x, kind: "kw" }));
+  return [...cols, ...fns];
 }
 
 function algebraCandidates(textBefore, start, schema) {

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -66,14 +66,19 @@ function lastClauseKeyword(text) {
   return last;
 }
 
+// Relations et attributs proposés en MAJUSCULES (SQLite et le compilateur d'algèbre
+// sont insensibles à la casse) ; les mots-clés/opérateurs sont déjà en majuscules.
+const upTables = (schema) => (schema.tables || []).map((x) => ({ label: x.toUpperCase(), kind: "table" }));
+const upCols = (list) => (list || []).map((x) => ({ label: x.toUpperCase(), kind: "col" }));
+
 function sqlCandidates(textBefore, start, qualifier, schema) {
-  const tables = (schema.tables || []).map((x) => ({ label: x, kind: "table" }));
-  const cols = (schema.allColumns || []).map((x) => ({ label: x, kind: "col" }));
+  const tables = upTables(schema);
+  const cols = upCols(schema.allColumns);
   const kw = [...SQL_KEYWORDS, ...SQL_FUNCTIONS].map((x) => ({ label: x, kind: "kw" }));
   if (qualifier) {
     const table = resolveTable(qualifier, textBefore, schema);
     const list = table && schema.columns[table] ? schema.columns[table] : (schema.allColumns || []);
-    return list.map((x) => ({ label: x, kind: "col" }));
+    return upCols(list);
   }
   const ctx = lastClauseKeyword(textBefore.slice(0, start));
   if (ctx === "FROM" || ctx === "JOIN") return [...tables, ...kw];
@@ -81,8 +86,8 @@ function sqlCandidates(textBefore, start, qualifier, schema) {
 }
 
 function algebraCandidates(textBefore, start, schema) {
-  const tables = (schema.tables || []).map((x) => ({ label: x, kind: "table" }));
-  const cols = (schema.allColumns || []).map((x) => ({ label: x, kind: "col" }));
+  const tables = upTables(schema);
+  const cols = upCols(schema.allColumns);
   const ops = ALGEBRA_OPERATORS.map((x) => ({ label: x, kind: "kw" }));
   const before = textBefore.slice(0, start);
   const trimmed = before.replace(/\s+$/, "");
@@ -95,8 +100,20 @@ function algebraCandidates(textBefore, start, schema) {
   return [...ops, ...tables, ...cols];
 }
 
+// Vrai si le curseur est dans une chaîne « non fermée » (échappement SQL '' géré).
+function inString(text) {
+  let inStr = false;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] !== "'") continue;
+    if (inStr && text[i + 1] === "'") { i++; continue; } // '' échappé
+    inStr = !inStr;
+  }
+  return inStr;
+}
+
 // Renvoie { start, word, items:[{label, kind}] } ; items filtrés par préfixe (casse ignorée).
 export function suggest(mode, textBefore, schema, force = false) {
+  if (inString(textBefore)) return { start: textBefore.length, word: "", items: [] };
   const wm = TRAILING_WORD.exec(textBefore);
   const word = wm ? wm[0] : "";
   const start = textBefore.length - word.length;

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -25,6 +25,10 @@ const SQL_FUNCTIONS = ["COUNT", "SUM", "AVG", "MIN", "MAX", "ROUND", "COALESCE",
 const SQL_TABLE_EXPECTING = ["FROM", "JOIN", ","];
 const SQL_AFTER_TABLE = ["JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "CROSS",
   "NATURAL", "ON", "WHERE", "GROUP", "ORDER", "HAVING"];
+// Mots-clés utiles en POSITION D'EXPRESSION (SELECT, WHERE...) : modificateurs et
+// opérateurs, mais PAS les démarreurs de clause (SELECT/FROM/WHERE/GROUP...).
+const SQL_EXPR_KW = ["DISTINCT", "AS", "AND", "OR", "NOT", "IN", "EXISTS", "IS", "NULL",
+  "LIKE", "BETWEEN", "CASE", "WHEN", "THEN", "ELSE", "END"];
 // Opérateurs relationnels seulement (proposés en début d'expression). Les connecteurs
 // ET/OU/NON ne sont PAS complétés : ils ne peuvent pas ouvrir une condition (on commence
 // par un attribut) et sont assez courts pour être tapés à la main.
@@ -119,8 +123,8 @@ function sqlCandidates(textBefore, start, qualifier, schema, fullText) {
   // Position d'expression (SELECT, WHERE, GROUP BY, ON...) : colonnes (restreintes aux
   // tables du FROM) + fonctions. Pas de tables ni de mots-clés de clause (bruit).
   const cols = upCols(inScopeColumns(src, schema) || schema.allColumns);
-  const fns = SQL_FUNCTIONS.map((x) => ({ label: x, kind: "kw" }));
-  return [...cols, ...fns];
+  const kw = [...SQL_FUNCTIONS, ...SQL_EXPR_KW].map((x) => ({ label: x, kind: "kw" }));
+  return [...cols, ...kw];
 }
 
 function algebraCandidates(textBefore, start, schema) {

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -29,6 +29,9 @@ const SQL_AFTER_TABLE = ["JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "CRO
 // opérateurs, mais PAS les démarreurs de clause (SELECT/FROM/WHERE/GROUP...).
 const SQL_EXPR_KW = ["DISTINCT", "AS", "AND", "OR", "NOT", "IN", "EXISTS", "IS", "NULL",
   "LIKE", "BETWEEN", "CASE", "WHEN", "THEN", "ELSE", "END"];
+// Après une COLONNE dans une condition (WHERE/ON/HAVING) : comparateurs + prédicats.
+const SQL_COMPARATORS = ["=", "<>", "<", ">", "<=", ">="];
+const SQL_PREDICATE_KW = ["IN", "LIKE", "BETWEEN", "IS", "NOT"];
 // Opérateurs relationnels seulement (proposés en début d'expression). Les connecteurs
 // ET/OU/NON ne sont PAS complétés : ils ne peuvent pas ouvrir une condition (on commence
 // par un attribut) et sont assez courts pour être tapés à la main.
@@ -87,6 +90,13 @@ function inScopeColumns(sql, schema) {
   return cols.length ? cols : null;
 }
 
+// Le jeton `name` est-il une colonne (en portée du FROM, sinon de la base) ?
+function isInScopeColumn(name, sql, schema) {
+  const scoped = inScopeColumns(sql, schema) || schema.allColumns || [];
+  const nl = String(name).toLowerCase();
+  return scoped.some((c) => c.toLowerCase() === nl);
+}
+
 function lastClauseKeyword(text) {
   let last = null, m;
   CLAUSE_KW.lastIndex = 0;
@@ -120,8 +130,16 @@ function sqlCandidates(textBefore, start, qualifier, schema, fullText) {
     if (SQL_TABLE_EXPECTING.includes(pt)) return upTables(schema);
     return SQL_AFTER_TABLE.map((x) => ({ label: x, kind: "kw" }));
   }
+  // Après une colonne dans une condition -> comparateurs + prédicats (IN, LIKE, IS...).
+  if ((ctx === "WHERE" || ctx === "ON" || ctx === "HAVING")
+      && isInScopeColumn(prevToken(textBefore.slice(0, start)), src, schema)) {
+    return [
+      ...SQL_COMPARATORS.map((x) => ({ label: x, kind: "op" })),
+      ...SQL_PREDICATE_KW.map((x) => ({ label: x, kind: "kw" })),
+    ];
+  }
   // Position d'expression (SELECT, WHERE, GROUP BY, ON...) : colonnes (restreintes aux
-  // tables du FROM) + fonctions. Pas de tables ni de mots-clés de clause (bruit).
+  // tables du FROM) + fonctions + mots-clés d'expression. Pas de tables ni de clause.
   const cols = upCols(inScopeColumns(src, schema) || schema.allColumns);
   const kw = [...SQL_FUNCTIONS, ...SQL_EXPR_KW].map((x) => ({ label: x, kind: "kw" }));
   return [...cols, ...kw];
@@ -379,7 +397,7 @@ export function suggest(mode, textBefore, schema, force = false, fullText = null
 
 // ── Popup (DOM) ──────────────────────────────────────────────────────────────
 
-const KIND_LABEL = { table: "table", rel: "relation", col: "colonne", kw: "mot-clé" };
+const KIND_LABEL = { table: "table", rel: "relation", col: "colonne", kw: "mot-clé", op: "opérateur" };
 
 // Coordonnées (px) du curseur dans le textarea, via un div-miroir.
 function caretCoords(textarea, position) {

--- a/templates/web-td/js/autocomplete.js
+++ b/templates/web-td/js/autocomplete.js
@@ -1,0 +1,235 @@
+// autocomplete.js - autocomplétion contextuelle de l'éditeur de requêtes, sans dépendance.
+//
+// Candidats tirés du schéma réel de la base (tables + colonnes, via engine.getSchema())
+// et des mots-clés SQL / opérateurs d'algèbre. Contextuelle :
+//   - SQL : après FROM/JOIN -> tables ; « alias. » ou « table. » -> colonnes de cette table ;
+//           ailleurs -> colonnes puis tables puis mots-clés.
+//   - Algèbre : après « / » -> attributs (+ ET/OU/NON) ; après « ( » ou « , » -> relations ;
+//               début d'expression / après « := » -> opérateurs.
+//
+// La logique de suggestion (suggest, buildAliasMap) est PURE (pas de DOM) et testée par
+// scripts/test-autocomplete.mjs. Le reste (popup, position du curseur) est du DOM.
+
+const SQL_KEYWORDS = [
+  "SELECT", "DISTINCT", "FROM", "WHERE", "GROUP", "BY", "HAVING", "ORDER", "ASC", "DESC",
+  "AND", "OR", "NOT", "IN", "EXISTS", "IS", "NULL", "LIKE", "BETWEEN", "AS", "ON", "USING",
+  "JOIN", "INNER", "LEFT", "RIGHT", "FULL", "OUTER", "CROSS", "NATURAL",
+  "UNION", "INTERSECT", "EXCEPT", "ALL", "ANY", "CASE", "WHEN", "THEN", "ELSE", "END",
+  "WITH", "RECURSIVE", "LIMIT", "OFFSET",
+];
+const SQL_FUNCTIONS = ["COUNT", "SUM", "AVG", "MIN", "MAX", "ROUND", "COALESCE",
+  "UPPER", "LOWER", "LENGTH", "SUBSTR"];
+const ALGEBRA_OPERATORS = [
+  "SELECTION", "PROJECTION", "RENOMMAGE", "UNION", "INTERSECTION", "DIFFERENCE",
+  "JOINTURE", "JOINTURE_NATURELLE", "DIVISION", "ET", "OU", "NON",
+];
+
+const IDENT = "[A-Za-z_\\u00C0-\\u024F][A-Za-z0-9_\\u00C0-\\u024F]*";
+const TRAILING_WORD = new RegExp(IDENT + "$");
+// FROM/JOIN font passer en « contexte tables » ; toute autre clause plus récente
+// repasse en « contexte colonnes » (la virgule n'est pas un mot-clé, donc « FROM a, » reste tables).
+const CLAUSE_KW = new RegExp(
+  "\\b(SELECT|FROM|WHERE|JOIN|ON|GROUP|ORDER|HAVING|BY|AND|OR|NOT|IN|LIKE|BETWEEN|" +
+  "SET|VALUES|UNION|EXCEPT|INTERSECT|AS|WITH|USING|CASE|WHEN|THEN|ELSE)\\b", "gi");
+
+// ── Logique de suggestion (pure) ─────────────────────────────────────────────
+
+export function buildAliasMap(sql) {
+  const map = {};
+  let m;
+  const joinRe = new RegExp("\\bJOIN\\s+(" + IDENT + ")(?:\\s+(?:AS\\s+)?(" + IDENT + "))?", "gi");
+  while ((m = joinRe.exec(sql)) !== null) map[(m[2] || m[1]).toLowerCase()] = m[1];
+  const fromRe = new RegExp(
+    "\\bFROM\\s+([\\s\\S]+?)(?=\\bWHERE\\b|\\bGROUP\\b|\\bORDER\\b|\\bHAVING\\b|\\bLIMIT\\b|" +
+    "\\bUNION\\b|\\bEXCEPT\\b|\\bINTERSECT\\b|\\bJOIN\\b|\\bON\\b|$)", "gi");
+  const itemRe = new RegExp("^\\s*(" + IDENT + ")(?:\\s+(?:AS\\s+)?(" + IDENT + "))?");
+  while ((m = fromRe.exec(sql)) !== null) {
+    for (const item of m[1].split(",")) {
+      const tm = itemRe.exec(item.trim());
+      if (tm) map[(tm[2] || tm[1]).toLowerCase()] = tm[1];
+    }
+  }
+  return map;
+}
+
+function resolveTable(qualifier, sql, schema) {
+  const map = buildAliasMap(sql);
+  const q = qualifier.toLowerCase();
+  const target = (map[q] || qualifier).toLowerCase();
+  return (schema.tables || []).find((t) => t.toLowerCase() === target) || null;
+}
+
+function lastClauseKeyword(text) {
+  let last = null, m;
+  CLAUSE_KW.lastIndex = 0;
+  while ((m = CLAUSE_KW.exec(text)) !== null) last = m[1].toUpperCase();
+  return last;
+}
+
+function sqlCandidates(textBefore, start, qualifier, schema) {
+  const tables = (schema.tables || []).map((x) => ({ label: x, kind: "table" }));
+  const cols = (schema.allColumns || []).map((x) => ({ label: x, kind: "col" }));
+  const kw = [...SQL_KEYWORDS, ...SQL_FUNCTIONS].map((x) => ({ label: x, kind: "kw" }));
+  if (qualifier) {
+    const table = resolveTable(qualifier, textBefore, schema);
+    const list = table && schema.columns[table] ? schema.columns[table] : (schema.allColumns || []);
+    return list.map((x) => ({ label: x, kind: "col" }));
+  }
+  const ctx = lastClauseKeyword(textBefore.slice(0, start));
+  if (ctx === "FROM" || ctx === "JOIN") return [...tables, ...kw];
+  return [...cols, ...tables, ...kw];
+}
+
+function algebraCandidates(textBefore, start, schema) {
+  const tables = (schema.tables || []).map((x) => ({ label: x, kind: "table" }));
+  const cols = (schema.allColumns || []).map((x) => ({ label: x, kind: "col" }));
+  const ops = ALGEBRA_OPERATORS.map((x) => ({ label: x, kind: "kw" }));
+  const before = textBefore.slice(0, start);
+  const trimmed = before.replace(/\s+$/, "");
+  if (trimmed === "" || trimmed.endsWith(":=")) return ops;
+  let j = start - 1;
+  while (j >= 0 && /\s/.test(textBefore[j])) j--;
+  const prev = j >= 0 ? textBefore[j] : "";
+  if (prev === "/") return [...cols, { label: "ET", kind: "kw" }, { label: "OU", kind: "kw" }, { label: "NON", kind: "kw" }];
+  if (prev === "(" || prev === ",") return [...tables, ...cols];
+  return [...ops, ...tables, ...cols];
+}
+
+// Renvoie { start, word, items:[{label, kind}] } ; items filtrés par préfixe (casse ignorée).
+export function suggest(mode, textBefore, schema, force = false) {
+  const wm = TRAILING_WORD.exec(textBefore);
+  const word = wm ? wm[0] : "";
+  const start = textBefore.length - word.length;
+  let qualifier = null;
+  if (start >= 1 && textBefore[start - 1] === ".") {
+    const qm = TRAILING_WORD.exec(textBefore.slice(0, start - 1));
+    if (qm) qualifier = qm[0];
+  }
+  if (!force && !qualifier && word.length < 1) return { start, word, items: [] };
+  const raw = mode === "algebra"
+    ? algebraCandidates(textBefore, start, schema)
+    : sqlCandidates(textBefore, start, qualifier, schema);
+  const w = word.toLowerCase();
+  const seen = new Set();
+  const items = [];
+  for (const it of raw) {
+    const low = it.label.toLowerCase();
+    if (!low.startsWith(w)) continue;
+    if (low === w && !qualifier) continue; // mot déjà tapé en entier : rien à ajouter
+    if (seen.has(low)) continue;
+    seen.add(low);
+    items.push(it);
+    if (items.length >= 40) break;
+  }
+  return { start, word, items };
+}
+
+// ── Popup (DOM) ──────────────────────────────────────────────────────────────
+
+const KIND_LABEL = { table: "table", col: "colonne", kw: "mot-clé" };
+
+// Coordonnées (px) du curseur dans le textarea, via un div-miroir.
+function caretCoords(textarea, position) {
+  const div = document.createElement("div");
+  const s = getComputedStyle(textarea);
+  const props = ["boxSizing", "width", "paddingTop", "paddingRight", "paddingBottom",
+    "paddingLeft", "borderTopWidth", "borderRightWidth", "borderBottomWidth",
+    "borderLeftWidth", "fontStyle", "fontVariant", "fontWeight", "fontStretch",
+    "fontSize", "fontFamily", "lineHeight", "letterSpacing", "textAlign",
+    "textTransform", "wordSpacing", "tabSize"];
+  for (const p of props) div.style[p] = s[p];
+  Object.assign(div.style, {
+    position: "absolute", visibility: "hidden", whiteSpace: "pre-wrap",
+    wordWrap: "break-word", overflow: "hidden", top: "0", left: "0",
+  });
+  div.textContent = textarea.value.slice(0, position);
+  const span = document.createElement("span");
+  span.textContent = textarea.value.slice(position) || ".";
+  div.appendChild(span);
+  document.body.appendChild(div);
+  const top = span.offsetTop + (parseInt(s.borderTopWidth) || 0);
+  const left = span.offsetLeft + (parseInt(s.borderLeftWidth) || 0);
+  const height = parseInt(s.lineHeight) || Math.round((parseInt(s.fontSize) || 14) * 1.3);
+  document.body.removeChild(div);
+  return { top, left, height };
+}
+
+export function attachAutocomplete(textarea, opts) {
+  const popup = document.createElement("ul");
+  popup.className = "ac-popup";
+  popup.style.display = "none";
+  document.body.appendChild(popup);
+  let items = [], active = -1, anchorStart = 0;
+
+  const isOpen = () => popup.style.display !== "none";
+  function close() { popup.style.display = "none"; items = []; active = -1; }
+
+  function render() {
+    popup.replaceChildren();
+    items.forEach((it, i) => {
+      const li = document.createElement("li");
+      li.className = "ac-item" + (i === active ? " ac-active" : "");
+      const label = document.createElement("span");
+      label.className = "ac-label"; label.textContent = it.label;
+      const kind = document.createElement("span");
+      kind.className = "ac-kind ac-kind-" + it.kind; kind.textContent = KIND_LABEL[it.kind] || it.kind;
+      li.append(label, kind);
+      li.addEventListener("mousedown", (e) => { e.preventDefault(); accept(i); });
+      popup.appendChild(li);
+    });
+    const cur = popup.children[active];
+    if (cur) cur.scrollIntoView({ block: "nearest" });
+  }
+
+  function position() {
+    const c = caretCoords(textarea, textarea.selectionStart);
+    const r = textarea.getBoundingClientRect();
+    popup.style.left = (window.scrollX + r.left + c.left - textarea.scrollLeft) + "px";
+    popup.style.top = (window.scrollY + r.top + c.top - textarea.scrollTop + c.height) + "px";
+  }
+
+  function update(force = false) {
+    if (textarea.selectionStart !== textarea.selectionEnd) return close();
+    const pos = textarea.selectionStart;
+    const res = suggest(opts.getMode(), textarea.value.slice(0, pos), opts.getSchema(), force);
+    if (!res.items.length) return close();
+    items = res.items; anchorStart = res.start; active = 0;
+    render();
+    popup.style.display = "block";
+    position();
+  }
+
+  function accept(i) {
+    if (i < 0 || i >= items.length) return;
+    const pos = textarea.selectionStart;
+    const insert = items[i].label;
+    textarea.value = textarea.value.slice(0, anchorStart) + insert + textarea.value.slice(pos);
+    textarea.selectionStart = textarea.selectionEnd = anchorStart + insert.length;
+    close();
+    textarea.focus();
+    if (opts.onInsert) opts.onInsert();
+  }
+
+  function handleKeydown(e) {
+    if (!isOpen()) {
+      if ((e.ctrlKey || e.metaKey) && (e.key === " " || e.code === "Space")) {
+        e.preventDefault(); update(true); return true;
+      }
+      return false;
+    }
+    switch (e.key) {
+      case "ArrowDown": e.preventDefault(); active = (active + 1) % items.length; render(); return true;
+      case "ArrowUp": e.preventDefault(); active = (active - 1 + items.length) % items.length; render(); return true;
+      case "Enter":
+        if (e.ctrlKey || e.metaKey) { close(); return false; } // Ctrl+Entrée : exécuter
+        e.preventDefault(); accept(active); return true;
+      case "Tab": e.preventDefault(); accept(active); return true;
+      case "Escape": e.preventDefault(); close(); return true;
+      default: return false;
+    }
+  }
+
+  textarea.addEventListener("input", () => update(false));
+  textarea.addEventListener("blur", () => setTimeout(close, 120));
+  return { handleKeydown, update, close, isOpen };
+}

--- a/templates/web-td/js/engine.js
+++ b/templates/web-td/js/engine.js
@@ -13,6 +13,7 @@ import { rewriteQuantifiers } from "./sql-quantifiers.js";
 
 let SQL = null;
 let snapshot = null;
+let schemaCache = null;
 
 // Fonctions SQL personnalisées, réenregistrées sur chaque base fraîche.
 // TO_DATE : les dates du jeu de données sont déjà au format ISO, la fonction est
@@ -34,6 +35,7 @@ export async function initEngine(schemaUrl, insertUrl) {
   db.run(schema);
   if (insert.trim()) db.run(insert);
   snapshot = db.export();
+  schemaCache = null;
   db.close();
 }
 
@@ -59,6 +61,43 @@ export function runQuery(sql) {
     return { cols, rows };
   } catch (e) {
     return { error: String(e.message || e) };
+  } finally {
+    db.close();
+  }
+}
+
+// Schéma de la base, pour l'autocomplétion : { tables:[...], columns:{table:[...]},
+// allColumns:[...] } (noms d'origine, casse préservée). Mis en cache.
+export function getSchema() {
+  if (schemaCache) return schemaCache;
+  const empty = { tables: [], columns: {}, allColumns: [] };
+  if (!SQL || !snapshot) return empty;
+  const db = new SQL.Database(snapshot);
+  try {
+    const tables = [];
+    const columns = {};
+    const res = db.exec(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name");
+    if (res.length) {
+      for (const row of res[0].values) {
+        const t = row[0];
+        tables.push(t);
+        const info = db.exec(`PRAGMA table_info("${String(t).replace(/"/g, '""')}")`);
+        columns[t] = info.length ? info[0].values.map((r) => r[1]) : []; // r[1] = name
+      }
+    }
+    const seen = new Set();
+    const allColumns = [];
+    for (const t of tables) {
+      for (const c of columns[t]) {
+        const k = c.toLowerCase();
+        if (!seen.has(k)) { seen.add(k); allColumns.push(c); }
+      }
+    }
+    schemaCache = { tables, columns, allColumns };
+    return schemaCache;
+  } catch {
+    return empty;
   } finally {
     db.close();
   }


### PR DESCRIPTION
## Quoi

Autocomplétion **contextuelle** dans l'éditeur de requêtes des pages TP (SQL **et** algèbre), sans nouvelle dépendance (vanilla JS, CSP-safe, vendorisé).

## Comment

- **Candidats depuis le schéma réel** de la base (`engine.getSchema()` via `PRAGMA table_info`) + mots-clés SQL / opérateurs d'algèbre.
- **Contextuel** :
  - SQL : après `FROM`/`JOIN` → **tables** ; `alias.` ou `table.` → **colonnes de cette table** (résolution des alias, y compris jointures par virgule) ; ailleurs → colonnes, puis tables, puis mots-clés.
  - Algèbre : après `/` → **attributs** (+ `ET/OU/NON`) ; après `(` ou `,` → **relations** ; début d'expression / après `:=` → **opérateurs**.
- **UX** : popup au niveau du curseur (div-miroir), navigation clavier (↑↓, Entrée/Tab pour insérer, Échap ; `Ctrl/Cmd+Espace` pour forcer ; `Ctrl+Entrée` exécute toujours).

## Fichiers

- `templates/web-td/js/autocomplete.js` (nouveau) — logique de suggestion **pure** (`suggest`, `buildAliasMap`, sans DOM) + popup.
- `engine.js` : `getSchema()` (tables/colonnes, en cache).
- `app.js` : branchement sur l'éditeur (interception clavier avant Tab/Ctrl+Entrée).
- `css/style.css` : style popup (thème clair/sombre).
- `scripts/test-autocomplete.mjs` (nouveau) — 13 cas sur la logique contextuelle, **ajouté au CI**.

## Vérifs

- Logique pure : **13/13**. Syntaxe ES OK. Pipeline de hash **non régressé** (TD7 23/23, TD1-algèbre 22/22). `autocomplete.js` bien copié et chargé en module.
- ⚠️ La partie **DOM (popup/position)** n'est pas testable en Node : à valider visuellement (servir une page, taper une requête).