### PR TITLE
docs: README dans chaque répertoire de TD

### DIFF
--- a/docs/r1.05/td1/README.md
+++ b/docs/r1.05/td1/README.md
@@ -1,0 +1,22 @@
+# R1.05 - TD1 : L'algèbre relationnelle
+
+TD1 de la ressource R1.05 (Introduction aux bases de données et SQL).
+
+## Contenu
+
+- `td1.md` : source Markdown du sujet
+- `td1-correction.md` : corrigé en algèbre relationnelle
+- `web-td.json` : manifeste de la version web (exercices d'algèbre interactifs)
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r1.05/td1/td1.pdf              # sujet
+make output/r1.05/td1/td1-correction.pdf   # corrigé
+```
+
+## Version web
+
+```bash
+make web-td1-algebre    # site interactif d'algèbre relationnelle (output/web/td1-algebre)
+```

--- a/docs/r1.05/td2/README.md
+++ b/docs/r1.05/td2/README.md
@@ -1,0 +1,24 @@
+# R1.05 - TD2 : Concepts relationnels et langage algébrique
+
+TD2 de la ressource R1.05 (Introduction aux bases de données et SQL).
+
+## Contenu
+
+- `td2.md` : source Markdown du sujet
+- `td2-correction.md` : corrigé en algèbre relationnelle
+- `web-td-ex1.json` : manifeste web de l'exercice 1 (base Airbase, formations)
+- `web-td-ex2.json` : manifeste web de l'exercice 2 (agence immobilière)
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r1.05/td2/td2.pdf              # sujet
+make output/r1.05/td2/td2-correction.pdf   # corrigé
+```
+
+## Versions web
+
+```bash
+make web-td2-airbase       # exercice 1 (output/web/td2-airbase)
+make web-td2-immobilier    # exercice 2 (output/web/td2-immobilier)
+```

--- a/docs/r1.05/td3/README.md
+++ b/docs/r1.05/td3/README.md
@@ -1,0 +1,21 @@
+# R1.05 - TD3 : Dépendances fonctionnelles et normalisation
+
+TD3 de la ressource R1.05 (Introduction aux bases de données et SQL).
+
+## Contenu
+
+- `td3.md` : source Markdown du sujet
+
+Pas encore de corrigé versionné : la conversion depuis le PDF original reste à faire.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r1.05/td3/td3.pdf
+```
+
+## Version web
+
+```bash
+make web-td3    # page minimale avec lien vers le PDF du sujet
+```

--- a/docs/r1.05/td4/README.md
+++ b/docs/r1.05/td4/README.md
@@ -1,0 +1,33 @@
+# R1.05 - TD4 : Modèle Entité/Association et traduction relationnelle
+
+TD4 de la ressource R1.05 (Introduction aux bases de données et SQL).
+
+## Contenu
+
+- `td4.md` : source Markdown du sujet
+- `figures/*.mcd` : sources Mocodo des MCD (gestion artistique 1 et 2, gestion sportive 1 et 2)
+- `figures/*_geo.json` : géométrie figée de chaque figure, versionnée et relue via `--reuse_geo`
+
+Pas encore de corrigé versionné : la conversion depuis le PDF original reste à faire.
+
+## Figures Mocodo
+
+Pipeline : `.mcd` -> Mocodo -> `.svg` -> Inkscape -> `.pdf`, orchestré par `make`.
+Le style commun (palette bleu/jaune, police Latin Modern Roman) est défini dans
+`templates/mocodo-colors.json` et `templates/mocodo-shapes.json`.
+
+Après modification d'un `.mcd` : relancer `mocodo` sans `--reuse_geo` pour recalculer
+la géométrie, l'ajuster à la main si besoin, puis committer le `_geo.json`.
+Détails dans le `CLAUDE.md` du dépôt (section « Figures Mocodo »).
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r1.05/td4/td4.pdf
+```
+
+## Version web
+
+```bash
+make web-td4    # page minimale avec lien vers le PDF du sujet
+```

--- a/docs/r1.05/td5/README.md
+++ b/docs/r1.05/td5/README.md
@@ -1,0 +1,21 @@
+# R1.05 - TD5 : Conception avec le modèle Entité/Association
+
+TD5 de la ressource R1.05 (Introduction aux bases de données et SQL).
+
+## Contenu
+
+- `td5.md` : source Markdown du sujet
+
+Pas encore de corrigé versionné : la conversion depuis le PDF original reste à faire.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r1.05/td5/td5.pdf
+```
+
+## Version web
+
+```bash
+make web-td5    # page minimale avec lien vers le PDF du sujet
+```

--- a/docs/r1.05/td6/README.md
+++ b/docs/r1.05/td6/README.md
@@ -1,0 +1,41 @@
+# R1.05 - TD6 : Interrogation en SQL
+
+TD6 de la ressource R1.05 (Introduction aux bases de données et SQL).
+
+## Contenu
+
+- `td6.md` : source Markdown du sujet, gabarit des versions générées
+- `td6-correction.sql` : corrigé SQL (syntaxe Oracle, annoté pour les tests automatisés)
+- `figures/mcd.tex` : MCD TikZ standalone (package `tikz-er2`), compilé en PDF par `make`
+- `data/` : lien symbolique vers `../../shared/data/airbase/` (`schema.sql` + `insert.sql`
+  pour PostgreSQL/SQLite, `oracle.sql` pour Oracle)
+
+Les fichiers `td6*.gen.md` (sujet, corrigé, corrigé enseignant) sont générés par
+`scripts/generate-questions.py`, qui injecte les requêtes du `.sql` dans le gabarit
+`td6.md`. Ils sont gitignorés, comme les PDF produits dans `output/`.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r1.05/td6/td6.pdf              # sujet
+make output/r1.05/td6/td6-correction.pdf   # corrigé étudiant
+make output/r1.05/td6/td6-teacher.pdf      # corrigé enseignant (avec remarques)
+```
+
+## Tests SQL
+
+```bash
+make test-sql-oracle-docker TD=td6     # référence : Oracle est le SGBD cible du cours
+make test-sql-sqlite-local TD=td6      # rapide, sans dépendance lourde
+make test-sql-postgresql-local TD=td6  # SGBD utilisé par la CI
+```
+
+`TD=td6` filtre par nom de répertoire (toutes ressources confondues). Les annotations
+`-- QN - c:X, t:Y` du fichier de correction donnent le nombre de colonnes et de lignes
+attendues pour chaque question.
+
+## Version web
+
+```bash
+make web-td6    # site interactif SQLite WASM (output/web/td6)
+```

--- a/docs/r1.05/td7/README.md
+++ b/docs/r1.05/td7/README.md
@@ -1,0 +1,41 @@
+# R1.05 - TD7 : Interrogation en SQL interprété
+
+TD7 de la ressource R1.05 (Introduction aux bases de données et SQL).
+
+## Contenu
+
+- `td7.md` : source Markdown du sujet, gabarit des versions générées
+- `td7-correction.sql` : corrigé SQL (syntaxe Oracle, annoté pour les tests automatisés)
+- `figures/mcd.tex` : MCD TikZ standalone (package `tikz-er2`), compilé en PDF par `make`
+- `data/` : lien symbolique vers `../../shared/data/voyages/` (`schema.sql` + `insert.sql`
+  pour PostgreSQL/SQLite, `oracle.sql` pour Oracle)
+
+Les fichiers `td7*.gen.md` (sujet, corrigé, corrigé enseignant) sont générés par
+`scripts/generate-questions.py`, qui injecte les requêtes du `.sql` dans le gabarit
+`td7.md`. Ils sont gitignorés, comme les PDF produits dans `output/`.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r1.05/td7/td7.pdf              # sujet
+make output/r1.05/td7/td7-correction.pdf   # corrigé étudiant
+make output/r1.05/td7/td7-teacher.pdf      # corrigé enseignant (avec remarques)
+```
+
+## Tests SQL
+
+```bash
+make test-sql-oracle-docker TD=td7     # référence : Oracle est le SGBD cible du cours
+make test-sql-sqlite-local TD=td7      # rapide, sans dépendance lourde
+make test-sql-postgresql-local TD=td7  # SGBD utilisé par la CI
+```
+
+`TD=td7` filtre par nom de répertoire (toutes ressources confondues). Les annotations
+`-- QN - c:X, t:Y` du fichier de correction donnent le nombre de colonnes et de lignes
+attendues pour chaque question.
+
+## Version web
+
+```bash
+make web-td7    # site interactif SQLite WASM (output/web/td7)
+```

--- a/docs/r2.06/td1/README.md
+++ b/docs/r2.06/td1/README.md
@@ -1,0 +1,44 @@
+# R2.06 - TD1 : Opérateurs ensemblistes, LDD et LCT
+
+TD1 de la ressource R2.06 (Exploitation d'une base de données).
+
+## Contenu
+
+- `td1.md` : source Markdown du sujet, gabarit des versions générées
+- `td1-correction.sql` : corrigé SQL (syntaxe Oracle, annoté pour les tests automatisés)
+- `figures/` : figures TikZ standalone (`mcd.tex`), compilées en PDF par `make`
+- `data/` : lien symbolique vers `../../shared/data/voyages/` (`schema.sql` + `insert.sql`
+  pour PostgreSQL/SQLite, `oracle.sql` pour Oracle)
+
+Les fichiers `td1*.gen.md` (sujet, corrigé, corrigé enseignant) sont générés par
+`scripts/generate-questions.py`, qui injecte les requêtes du `.sql` dans le gabarit
+`td1.md`. Ils sont gitignorés, comme les PDF produits dans `output/`.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r2.06/td1/td1.pdf              # sujet
+make output/r2.06/td1/td1-correction.pdf   # corrigé étudiant
+make output/r2.06/td1/td1-teacher.pdf      # corrigé enseignant (avec remarques)
+```
+
+## Tests SQL
+
+```bash
+make test-sql-oracle-docker TD=td1     # référence : Oracle est le SGBD cible du cours
+make test-sql-sqlite-local TD=td1      # rapide, sans dépendance lourde
+make test-sql-postgresql-local TD=td1  # SGBD utilisé par la CI
+```
+
+`TD=td1` filtre par nom de répertoire (toutes ressources confondues). Les annotations
+`-- QN - c:X, t:Y` du fichier de correction donnent le nombre de colonnes et de lignes
+attendues pour chaque question.
+
+Les questions LDD/LMD (créations, mises à jour, transactions) n'ont pas d'annotations
+`c:t` : elles ne retournent pas de résultat tabulaire.
+
+## Version web
+
+```bash
+make web-r206-td1    # site interactif SQLite WASM (output/web/r206-td1)
+```

--- a/docs/r2.06/td2/README.md
+++ b/docs/r2.06/td2/README.md
@@ -1,0 +1,42 @@
+# R2.06 - TD2 : Jointures externes, partitionnement et synthèse des requêtes
+
+TD2 de la ressource R2.06 (Exploitation d'une base de données).
+
+## Contenu
+
+- `td2.md` : source Markdown du sujet, gabarit des versions générées
+- `td2-correction.sql` : corrigé SQL (syntaxe Oracle, annoté pour les tests automatisés)
+- `figures/` : figures TikZ standalone (`mcd.tex`), compilées en PDF par `make`
+- `data/` : lien symbolique vers `../../shared/data/voyages/` (`schema.sql` + `insert.sql`
+  pour PostgreSQL/SQLite, `oracle.sql` pour Oracle)
+- `web-td.json` : manifeste de la version web (questions exclues ou aménagées pour SQLite)
+
+Les fichiers `td2*.gen.md` (sujet, corrigé, corrigé enseignant) sont générés par
+`scripts/generate-questions.py`, qui injecte les requêtes du `.sql` dans le gabarit
+`td2.md`. Ils sont gitignorés, comme les PDF produits dans `output/`.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r2.06/td2/td2.pdf              # sujet
+make output/r2.06/td2/td2-correction.pdf   # corrigé étudiant
+make output/r2.06/td2/td2-teacher.pdf      # corrigé enseignant (avec remarques)
+```
+
+## Tests SQL
+
+```bash
+make test-sql-oracle-docker TD=td2     # référence : Oracle est le SGBD cible du cours
+make test-sql-sqlite-local TD=td2      # rapide, sans dépendance lourde
+make test-sql-postgresql-local TD=td2  # SGBD utilisé par la CI
+```
+
+`TD=td2` filtre par nom de répertoire (toutes ressources confondues). Les annotations
+`-- QN - c:X, t:Y` du fichier de correction donnent le nombre de colonnes et de lignes
+attendues pour chaque question.
+
+## Version web
+
+```bash
+make web-r206-td2    # site interactif SQLite WASM (output/web/r206-td2)
+```

--- a/docs/r2.06/td3/README.md
+++ b/docs/r2.06/td3/README.md
@@ -1,0 +1,41 @@
+# R2.06 - TD3 : Interrogations en SQL
+
+TD3 de la ressource R2.06 (Exploitation d'une base de données).
+
+## Contenu
+
+- `td3.md` : source Markdown du sujet, gabarit des versions générées
+- `td3-correction.sql` : corrigé SQL (syntaxe Oracle, annoté pour les tests automatisés)
+- `figures/` : figures TikZ standalone (`mcd.tex`, `hierarchie-modules.tex`), compilées en PDF par `make`
+- `data/` : lien symbolique vers `../../shared/data/gestion-pedagogique/` (`schema.sql` + `insert.sql`
+  pour PostgreSQL/SQLite, `oracle.sql` pour Oracle)
+
+Les fichiers `td3*.gen.md` (sujet, corrigé, corrigé enseignant) sont générés par
+`scripts/generate-questions.py`, qui injecte les requêtes du `.sql` dans le gabarit
+`td3.md`. Ils sont gitignorés, comme les PDF produits dans `output/`.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r2.06/td3/td3.pdf              # sujet
+make output/r2.06/td3/td3-correction.pdf   # corrigé étudiant
+make output/r2.06/td3/td3-teacher.pdf      # corrigé enseignant (avec remarques)
+```
+
+## Tests SQL
+
+```bash
+make test-sql-oracle-docker TD=td3     # référence : Oracle est le SGBD cible du cours
+make test-sql-sqlite-local TD=td3      # rapide, sans dépendance lourde
+make test-sql-postgresql-local TD=td3  # SGBD utilisé par la CI
+```
+
+`TD=td3` filtre par nom de répertoire (toutes ressources confondues). Les annotations
+`-- QN - c:X, t:Y` du fichier de correction donnent le nombre de colonnes et de lignes
+attendues pour chaque question.
+
+## Version web
+
+```bash
+make web-r206-td3    # site interactif SQLite WASM (output/web/r206-td3)
+```

--- a/docs/r2.06/td4/README.md
+++ b/docs/r2.06/td4/README.md
@@ -1,0 +1,41 @@
+# R2.06 - TD4 : Recherche récursive, division et requêtes complexes
+
+TD4 de la ressource R2.06 (Exploitation d'une base de données).
+
+## Contenu
+
+- `td4.md` : source Markdown du sujet, gabarit des versions générées
+- `td4-correction.sql` : corrigé SQL (syntaxe Oracle, annoté pour les tests automatisés)
+- `figures/` : figures TikZ standalone (`mcd.tex`, `hierarchie-themes.tex`), compilées en PDF par `make`
+- `data/` : lien symbolique vers `../../shared/data/questionnaire/` (`schema.sql` + `insert.sql`
+  pour PostgreSQL/SQLite, `oracle.sql` pour Oracle)
+
+Les fichiers `td4*.gen.md` (sujet, corrigé, corrigé enseignant) sont générés par
+`scripts/generate-questions.py`, qui injecte les requêtes du `.sql` dans le gabarit
+`td4.md`. Ils sont gitignorés, comme les PDF produits dans `output/`.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r2.06/td4/td4.pdf              # sujet
+make output/r2.06/td4/td4-correction.pdf   # corrigé étudiant
+make output/r2.06/td4/td4-teacher.pdf      # corrigé enseignant (avec remarques)
+```
+
+## Tests SQL
+
+```bash
+make test-sql-oracle-docker TD=td4     # référence : Oracle est le SGBD cible du cours
+make test-sql-sqlite-local TD=td4      # rapide, sans dépendance lourde
+make test-sql-postgresql-local TD=td4  # SGBD utilisé par la CI
+```
+
+`TD=td4` filtre par nom de répertoire (toutes ressources confondues). Les annotations
+`-- QN - c:X, t:Y` du fichier de correction donnent le nombre de colonnes et de lignes
+attendues pour chaque question.
+
+## Version web
+
+```bash
+make web-r206-td4    # site interactif SQLite WASM (output/web/r206-td4)
+```

--- a/docs/r2.06/td5/README.md
+++ b/docs/r2.06/td5/README.md
@@ -1,0 +1,42 @@
+# R2.06 - TD5 : Interrogations avancées en SQL
+
+TD5 de la ressource R2.06 (Exploitation d'une base de données).
+
+## Contenu
+
+- `td5.md` : source Markdown du sujet, gabarit des versions générées
+- `td5-correction.sql` : corrigé SQL (syntaxe Oracle, annoté pour les tests automatisés)
+- `figures/` : figures TikZ standalone (`mcd.tex`, `hierarchie-modules.tex`), compilées en PDF par `make`
+- `data/` : lien symbolique vers `../../shared/data/gestion-pedagogique/` (`schema.sql` + `insert.sql`
+  pour PostgreSQL/SQLite, `oracle.sql` pour Oracle)
+- `web-td.json` : manifeste de la version web (questions exclues ou aménagées pour SQLite)
+
+Les fichiers `td5*.gen.md` (sujet, corrigé, corrigé enseignant) sont générés par
+`scripts/generate-questions.py`, qui injecte les requêtes du `.sql` dans le gabarit
+`td5.md`. Ils sont gitignorés, comme les PDF produits dans `output/`.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r2.06/td5/td5.pdf              # sujet
+make output/r2.06/td5/td5-correction.pdf   # corrigé étudiant
+make output/r2.06/td5/td5-teacher.pdf      # corrigé enseignant (avec remarques)
+```
+
+## Tests SQL
+
+```bash
+make test-sql-oracle-docker TD=td5     # référence : Oracle est le SGBD cible du cours
+make test-sql-sqlite-local TD=td5      # rapide, sans dépendance lourde
+make test-sql-postgresql-local TD=td5  # SGBD utilisé par la CI
+```
+
+`TD=td5` filtre par nom de répertoire (toutes ressources confondues). Les annotations
+`-- QN - c:X, t:Y` du fichier de correction donnent le nombre de colonnes et de lignes
+attendues pour chaque question.
+
+## Version web
+
+```bash
+make web-r206-td5    # site interactif SQLite WASM (output/web/r206-td5)
+```

--- a/docs/r2.06/td6/README.md
+++ b/docs/r2.06/td6/README.md
@@ -1,0 +1,41 @@
+# R2.06 - TD6 : Vues, tables système et rappels SQL
+
+TD6 de la ressource R2.06 (Exploitation d'une base de données).
+
+## Contenu
+
+- `td6.md` : source Markdown du sujet, gabarit des versions générées
+- `td6-correction.sql` : corrigé SQL (syntaxe Oracle, annoté pour les tests automatisés)
+- `figures/` : figures TikZ standalone (`mcd.tex`, `hierarchie-modules.tex`), compilées en PDF par `make`
+- `data/` : lien symbolique vers `../../shared/data/gestion-pedagogique/` (`schema.sql` + `insert.sql`
+  pour PostgreSQL/SQLite, `oracle.sql` pour Oracle)
+
+Les fichiers `td6*.gen.md` (sujet, corrigé, corrigé enseignant) sont générés par
+`scripts/generate-questions.py`, qui injecte les requêtes du `.sql` dans le gabarit
+`td6.md`. Ils sont gitignorés, comme les PDF produits dans `output/`.
+
+## Compilation (depuis la racine du dépôt)
+
+```bash
+make output/r2.06/td6/td6.pdf              # sujet
+make output/r2.06/td6/td6-correction.pdf   # corrigé étudiant
+make output/r2.06/td6/td6-teacher.pdf      # corrigé enseignant (avec remarques)
+```
+
+## Tests SQL
+
+```bash
+make test-sql-oracle-docker TD=td6     # référence : Oracle est le SGBD cible du cours
+make test-sql-sqlite-local TD=td6      # rapide, sans dépendance lourde
+make test-sql-postgresql-local TD=td6  # SGBD utilisé par la CI
+```
+
+`TD=td6` filtre par nom de répertoire (toutes ressources confondues). Les annotations
+`-- QN - c:X, t:Y` du fichier de correction donnent le nombre de colonnes et de lignes
+attendues pour chaque question.
+
+## Version web
+
+```bash
+make web-r206-td6    # page minimale avec lien vers le PDF du sujet
+```


### PR DESCRIPTION
## Résumé

Ajoute un README.md dans les 13 répertoires de TD (7 pour R1.05, 6 pour R2.06). Chaque README documente :

- le contenu du répertoire (sujet, corrigé, figures, lien symbolique data/, manifestes web)
- le mécanisme des fichiers générés (*.gen.md via scripts/generate-questions.py) pour les TD avec corrections SQL
- les commandes de compilation PDF (sujet, corrigé, corrigé enseignant)
- les commandes de tests SQL multi-SGBD avec le filtre TD=
- la cible make de la version web (site interactif ou page minimale)

Le TD4 R1.05 documente aussi le pipeline Mocodo (sources .mcd, géométrie _geo.json, procédure de régénération).

## Remarques

- Aucun impact sur le build : les scripts et le Makefile ne globent que td*.md, les README ne sont pas ramassés.
- Contenu factuel vérifié contre le Makefile (cibles, chemins) et les répertoires réels.