### PR TITLE
feat: Titre et intro pour la page web du TD3 R2.06

### DIFF
--- a/docs/r2.06/td3/td3-correction.sql
+++ b/docs/r2.06/td3/td3-correction.sql
@@ -1,5 +1,8 @@
 -- V1.1.0
 
+-- @title Requêtes avec SQL
+-- @intro Formulez, en SQL, sur la base de données exemple, les requêtes d'interrogation suivantes.
+
 -- @section Expression des jointures
 -- @instruction Quand cela possible, formulez les requêtes suivantes de trois manières différentes.
 


### PR DESCRIPTION
## Résumé

Le TD3 R2.06 était le seul TD SQL sans annotations `-- @title` / `-- @intro` en tête de sa correction : sa page web affichait "R2.06 - TD3 - " (titre vide) et son README généré n'avait pas de sous-titre.

Ajout des deux annotations dans le même format que tous les autres TD (td1/td2/td4/td5 R2.06, td6/td7 R1.05) :

- `@title Requêtes avec SQL` (libellé commun à tous les TD SQL)
- `@intro Formulez, en SQL, sur la base de données exemple, les requêtes d'interrogation suivantes.`

## Vérifications

- Site régénéré : questions.json porte bien title + intro, h1 complet
- `verify-web-td.mjs` : 26/26 OK, 75 vérifications hash Python == WASM
- `sqlfluff lint` : propre ; tests SQLite : échecs identiques avant/après (10, syntaxes Oracle-only connues)

Après merge, la publication chaînée mettra à jour la page et le README de IUTInfoAix-R206/TD3.