### PR TITLE
fix: Retirer le lien vers Documents des README étudiants

### DIFF
--- a/scripts/generate-repo-readme.py
+++ b/scripts/generate-repo-readme.py
@@ -29,8 +29,7 @@ RES_LABELS = {
 }
 
 AUTO_NOTE = (
-    "Ce dépôt est généré automatiquement depuis le dépôt "
-    "[Documents](https://github.com/IUTInfoAix-R105-R206/Documents) : "
+    "Ce dépôt est généré automatiquement : "
     "toute modification manuelle sera écrasée à la prochaine publication."
 )
 


### PR DESCRIPTION
Le dépôt Documents va devenir privé : le lien dans la note « généré automatiquement » des README étudiants serait mort pour les étudiants. La note est conservée sans nom ni lien de dépôt. Testé en dry-run : plus aucune référence à Documents dans le README généré. Après merge, la publication chaînée mettra à jour les 13 dépôts.