### PR TITLE
feat: Release automatique par PR fusionnée (semantic-release)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,18 +1,74 @@
 # .github/workflows/release.yml
-# Compile les PDF et crée une release GitHub avec archive ZIP à chaque tag de version
+# Release automatique à chaque PR fusionnée sur main, via semantic-release.
+#
+# Job « version » : semantic-release analyse les messages de commit
+# (Conventional Commits, convention des titres de PR squash-mergées) :
+# feat -> minor, fix -> patch, « BREAKING CHANGE » -> major ; les autres types
+# (docs, ci, chore, style, refactor, build, test, update) donnent un patch
+# (.releaserc.json), de sorte que chaque PR fusionnée produit une release.
+# Il crée le tag v<version> et la release GitHub avec les notes générées.
+#
+# Job « assets » : compile tous les PDF (version forcée au tag), les corrigés
+# nettoyés et les scripts Oracle, puis attache l'archive ZIP à la release.
+# Le chaînage se fait par « needs » : le tag étant poussé avec le
+# GITHUB_TOKEN, un déclencheur « on: push: tags » ne se lancerait jamais.
 
 name: Release
 
 on:
   push:
-    tags: ['v*']
+    branches: [main]
+
+permissions:
+  contents: write        # tags + releases
+  issues: write          # commentaire sur les issues liées à la release
+  pull-requests: write   # commentaire sur les PR incluses dans la release
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  release:
+  version:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    outputs:
+      released: ${{ steps.semrel.outputs.released }}
+      tag: ${{ steps.semrel.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0            # historique complet requis par semantic-release
+          persist-credentials: false
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install semantic-release
+        run: npm install --no-save semantic-release@24 conventional-changelog-conventionalcommits@8
+
+      - name: Run semantic-release
+        id: semrel
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npx semantic-release
+          # semantic-release tagge HEAD en local avant de pousser : un tag v*
+          # pointant sur HEAD signifie qu'une release vient d'être publiée.
+          tag=$(git tag --points-at HEAD | grep '^v' | head -1 || true)
+          if [ -n "$tag" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "tag=$tag" >> "$GITHUB_OUTPUT"
+            echo "Release publiée : $tag"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+            echo "Aucune release (pas de commit déclencheur)."
+          fi
+
+  assets:
+    needs: version
+    if: needs.version.outputs.released == 'true'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -40,11 +96,14 @@ jobs:
             lmodern \
             inkscape
 
+      - name: Install Mocodo (figures MCD)
+        run: pipx install "$(grep '^mocodo' requirements.txt)"
+
       - name: Build all PDFs
-        run: make all GIT_VERSION=${{ github.ref_name }}
+        run: make all GIT_VERSION=${{ needs.version.outputs.tag }}
 
       - name: Build teacher PDFs
-        run: make teacher GIT_VERSION=${{ github.ref_name }}
+        run: make teacher GIT_VERSION=${{ needs.version.outputs.tag }}
 
       - name: Generate clean SQL corrections
         run: make clean-corrections
@@ -60,13 +119,11 @@ jobs:
           done
 
       - name: Create ZIP archive
-        run: cd output && zip -r ../Documents-${{ github.ref_name }}.zip .
+        run: cd output && zip -r ../Documents-${{ needs.version.outputs.tag }}.zip .
 
-      - name: Create GitHub Release
+      - name: Upload ZIP to release
         run: |
-          gh release create ${{ github.ref_name }} \
-            Documents-${{ github.ref_name }}.zip \
-            --title "${{ github.ref_name }}" \
-            --generate-notes
+          gh release upload ${{ needs.version.outputs.tag }} \
+            Documents-${{ needs.version.outputs.tag }}.zip --clobber
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,44 @@
+{
+  "branches": ["main"],
+  "tagFormat": "v${version}",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "type": "docs", "release": "patch" },
+          { "type": "ci", "release": "patch" },
+          { "type": "chore", "release": "patch" },
+          { "type": "style", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "test", "release": "patch" },
+          { "type": "update", "release": "patch" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "feat", "section": "Nouveautés" },
+            { "type": "fix", "section": "Corrections" },
+            { "type": "perf", "section": "Performances" },
+            { "type": "refactor", "section": "Refactoring" },
+            { "type": "docs", "section": "Documentation" },
+            { "type": "style", "section": "Style" },
+            { "type": "ci", "section": "CI" },
+            { "type": "build", "section": "Build" },
+            { "type": "test", "section": "Tests" },
+            { "type": "chore", "section": "Maintenance" },
+            { "type": "update", "section": "Mises à jour" }
+          ]
+        }
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}


### PR DESCRIPTION
## Résumé

Chaque PR fusionnée sur main produit désormais automatiquement un tag et une release GitHub, via semantic-release.

## Fonctionnement

**Job version** (a chaque push sur main) :
- Analyse des messages de commit (Conventional Commits = titres des PR squash-mergées) : feat -> minor, fix -> patch, BREAKING CHANGE -> major
- Les autres types (docs, ci, chore, style, refactor, build, test, update) donnent un patch (.releaserc.json), pour que chaque PR fusionnée déclenche bien une release
- Tag v<version> (continuité avec les tags existants v0.0.1..v0.1.6) + release GitHub avec notes en français par sections (Nouveautés, Corrections, Documentation...)
- semantic-release commente aussi chaque PR incluse ("included in version...")

**Job assets** (si release publiée) : reprend l'ancien workflow déclenché par tag manuel - compilation de tous les PDF avec la version forcée au tag, corrigés enseignants, corrections SQL nettoyées, scripts Oracle - et attache le ZIP complet à la release.

Le chaînage se fait par needs entre jobs : un tag poussé avec le GITHUB_TOKEN ne déclenche aucun workflow, l'ancien déclencheur "on: push: tags" serait devenu muet.

## Corrections au passage

- L'ancien job de release n'installait pas Mocodo : un tag manuel posé aujourd'hui aurait échoué sur make all (figures MCD du TD4 R1.05). Ajout du pipx install.

## Validation

Dry-run local complet : permissions vérifiées, prochaine version calculée v0.2.0, notes générées couvrant les 37 commits depuis v0.1.6 avec sections françaises.

## Après merge

Le merge de cette PR déclenchera lui-même la première release automatique (v0.2.0, gros rattrapage depuis v0.1.6) avec son ZIP de PDF.